### PR TITLE
Tweak to allow a "TextField" to be used instead of a "CharField" for parameter inputs

### DIFF
--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -86,7 +86,7 @@ class WooeyFormFactory(object):
             form_field = 'MultipleChoiceField' if multiple_choices else 'ChoiceField'
             base_choices = [(None, '----')] if not param.required and not multiple_choices else []
             field_kwargs['choices'] = base_choices+[(str(i), str(i).title()) for i in choices]
-         if form_field == 'TextField':
+        if form_field == 'TextField':
             form_field = 'CharField'
             field_kwargs = {'widget': forms.Textarea}
             widget_data_dict.update({'style': 'display: block'})  #slightly dirty hack to make a Text box appear on a new line, rather than next to its label

--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -86,6 +86,10 @@ class WooeyFormFactory(object):
             form_field = 'MultipleChoiceField' if multiple_choices else 'ChoiceField'
             base_choices = [(None, '----')] if not param.required and not multiple_choices else []
             field_kwargs['choices'] = base_choices+[(str(i), str(i).title()) for i in choices]
+         if form_field == 'TextField':
+            form_field = 'CharField'
+            field_kwargs = {'widget': forms.Textarea}
+            widget_data_dict.update({'style': 'display: block'})  #slightly dirty hack to make a Text box appear on a new line, rather than next to its label
         if form_field == 'FileField':
             if param.is_output:
                 form_field = 'CharField'


### PR DESCRIPTION
Tweak to allow a "TextField" to be used instead of a "CharField" for parameter inputs (user has to manually change the "Form field" setting in the admin).

No worries if this is not a feature you want to add!