### PR TITLE
Ephemeral file system fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ coveralls
 six
 clinto
 tox
+boto
+django-storages-redux

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,11 @@ envlist =
     {py27,py34}-{1.7.X},
     {py27,py34}-{1.8.X}
 [testenv]
+passenv =
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_STORAGE_BUCKET_NAME
+    AWS_S3_CUSTOM_DOMAIN
 basepython =
     py27: python2.7
     py33: python3.3

--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -169,7 +169,7 @@ def add_wooey_script(script=None, group=None):
         # handle remotely first, because by default scripts will be saved remotely if we are using an
         # ephemeral file system
         old_name = script.script_path.name
-        new_name = os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, old_name) if not old_name.startswith(wooey_settings.WOOEY_SCRIPT_DIR) else old_name
+        new_name = os.path.normpath(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, old_name) if not old_name.startswith(wooey_settings.WOOEY_SCRIPT_DIR) else old_name)
 
         current_storage = get_storage(local=not wooey_settings.WOOEY_EPHEMERAL_FILES)
         current_file = current_storage.open(old_name)

--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -208,7 +208,7 @@ def add_wooey_script(script=None, group=None):
 
     parser = Parser(script_name=filename, script_path=local_storage.path(local_file))
     if not parser.valid:
-        return (False, parser.error)
+        return {'valid': False, 'errors': parser.error}
     # make our script
     d = parser.get_script_description()
     script_group, created = ScriptGroup.objects.get_or_create(group_name=group)
@@ -246,7 +246,7 @@ def add_wooey_script(script=None, group=None):
                                                                           choices=json.dumps(param.get('choices')), choice_limit=json.dumps(param.get('choice_limit', 1)),
                                                                           param_help=param.get('help'), is_checked=param.get('checked', False),
                                                                           parameter_group=param_group)
-    return (True, '')
+    return {'valid': True, 'errors': None, 'script': wooey_script}
 
 def valid_user(obj, user):
     groups = obj.user_groups.all()

--- a/wooey/management/commands/addscript.py
+++ b/wooey/management/commands/addscript.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                         # save it locally as well (the default_storage will default to the remote store)
                         local_storage = get_storage(local=True)
                         local_storage.save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, os.path.split(script)[1]), File(f))
-                added, error = add_wooey_script(script=script, group=group)
-                if added:
+                res = add_wooey_script(script=script, group=group)
+                if res['valid']:
                     converted += 1
         sys.stdout.write('Converted {} scripts\n'.format(converted))

--- a/wooey/management/commands/addscript.py
+++ b/wooey/management/commands/addscript.py
@@ -3,10 +3,9 @@ import os
 import sys
 from django.core.management.base import BaseCommand, CommandError
 from django.core.files import File
-from django.core.files.storage import default_storage
 from django.conf import settings
 
-from ...backend.utils import add_wooey_script
+from ...backend.utils import add_wooey_script, get_storage, default_storage
 from ... import settings as wooey_settings
 
 
@@ -40,6 +39,11 @@ class Command(BaseCommand):
                 # copy the script to our storage
                 with open(script, 'r') as f:
                     script = default_storage.save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, os.path.split(script)[1]), File(f))
+                    if wooey_settings.WOOEY_EPHEMERAL_FILES:
+                        # save it locally as well (the default_storage will default to the remote store)
+                        local_storage = get_storage(local=True)
+                        local_storage.save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, os.path.split(script)[1]), File(f))
+
                 added, error = add_wooey_script(script=os.path.abspath(os.path.join(settings.MEDIA_ROOT, script)), group=group)
                 if added:
                     converted += 1

--- a/wooey/management/commands/addscript.py
+++ b/wooey/management/commands/addscript.py
@@ -43,8 +43,7 @@ class Command(BaseCommand):
                         # save it locally as well (the default_storage will default to the remote store)
                         local_storage = get_storage(local=True)
                         local_storage.save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, os.path.split(script)[1]), File(f))
-
-                added, error = add_wooey_script(script=os.path.abspath(os.path.join(settings.MEDIA_ROOT, script)), group=group)
+                added, error = add_wooey_script(script=script, group=group)
                 if added:
                     converted += 1
         sys.stdout.write('Converted {} scripts\n'.format(converted))

--- a/wooey/signals.py
+++ b/wooey/signals.py
@@ -49,7 +49,7 @@ def script_presave(instance, **kwargs):
 
 def script_postsave(instance, created, **kwargs):
     from .backend import utils
-    if created and not skip_script(instance):
+    if created and (not skip_script(instance) or getattr(instance, '_script_upgrade', False)):
         added, error = utils.add_wooey_script(script=instance, group=instance.script_group)
         instance._script_upgrade = False
         instance._script_cl_creation = False

--- a/wooey/signals.py
+++ b/wooey/signals.py
@@ -50,15 +50,15 @@ def script_presave(instance, **kwargs):
 def script_postsave(instance, created, **kwargs):
     from .backend import utils
     if created and (not skip_script(instance) or getattr(instance, '_script_upgrade', False)):
-        added, error = utils.add_wooey_script(script=instance, group=instance.script_group)
+        res = utils.add_wooey_script(script=instance, group=instance.script_group)
         instance._script_upgrade = False
         instance._script_cl_creation = False
         instance._rename_script = False
-        if added is False:
+        if res['valid'] is False:
             # delete the model on exceptions.
             # TODO: use django messages backend to propogate this message to the admin
             instance.delete()
-            raise BaseException(error)
+            raise BaseException(res['errors'])
     utils.load_scripts()
 
 pre_save.connect(script_presave, sender=Script)

--- a/wooey/test_settings.py
+++ b/wooey/test_settings.py
@@ -56,3 +56,45 @@ PASSWORD_HASHERS = (
 MIDDLEWARE_CLASSES = []
 
 ROOT_URLCONF = 'wooey.urls'
+
+WOOEY_EPHEMERAL_FILES = True
+WOOEY_CELERY = False
+WOOEY_FILE_DIR = 'wooey_test'
+
+if os.environ.get('AWS_ACCESS_KEY_ID'):
+    STATICFILES_STORAGE = DEFAULT_FILE_STORAGE = 'wooey.wooeystorage.CachedS3BotoStorage'
+    from boto.s3.connection import VHostCallingFormat
+
+    INSTALLED_APPS += (
+        'storages',
+    )
+
+    AWS_CALLING_FORMAT = VHostCallingFormat
+
+    AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+    AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+    AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+    AWS_AUTO_CREATE_BUCKET = True
+    AWS_QUERYSTRING_AUTH = False
+    AWS_FILE_OVERWRITE = False
+    AWS_PRELOAD_METADATA = True
+    AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
+
+    GZIP_CONTENT_TYPES = (
+        'text/css',
+        'application/javascript',
+        'application/x-javascript',
+        'text/javascript',
+    )
+
+    AWS_EXPIREY = 60 * 60 * 7
+    AWS_HEADERS = {
+        'Cache-Control': 'max-age=%d, s-maxage=%d, must-revalidate' % (AWS_EXPIREY,
+            AWS_EXPIREY)
+    }
+
+    STATIC_URL = 'http://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+    MEDIA_URL = '/user-uploads/'
+
+else:
+    STATICFILES_STORAGE = DEFAULT_FILE_STORAGE = 'wooey.wooeystorage.FakeRemoteStorage'

--- a/wooey/test_settings.py
+++ b/wooey/test_settings.py
@@ -61,7 +61,7 @@ WOOEY_EPHEMERAL_FILES = True
 WOOEY_CELERY = False
 WOOEY_FILE_DIR = 'wooey_test'
 
-if os.environ.get('AWS_ACCESS_KEY_ID'):
+if os.environ.get('WOOEY_TEST_S3'):
     STATICFILES_STORAGE = DEFAULT_FILE_STORAGE = 'wooey.wooeystorage.CachedS3BotoStorage'
     from boto.s3.connection import VHostCallingFormat
 

--- a/wooey/test_settings.py
+++ b/wooey/test_settings.py
@@ -76,7 +76,7 @@ if os.environ.get('WOOEY_TEST_S3'):
     AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
     AWS_AUTO_CREATE_BUCKET = True
     AWS_QUERYSTRING_AUTH = False
-    AWS_FILE_OVERWRITE = False
+    AWS_S3_FILE_OVERWRITE = False
     AWS_PRELOAD_METADATA = True
     AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
 

--- a/wooey/tests/config.py
+++ b/wooey/tests/config.py
@@ -8,7 +8,7 @@ BASE_DIR = os.path.split(__file__)[0]
 WOOEY_TEST_SCRIPTS = os.path.join(BASE_DIR, 'scripts')
 WOOEY_TEST_DATA = os.path.join(BASE_DIR, 'data')
 WOOEY_TEST_REMOTE_STORAGE_DIR = 'remote_storage'
-WOOEY_TEST_REMOTE_STORAGE_PATH = os.path.join(settings.MEDIA_ROOT, 'remote_storage')
+WOOEY_TEST_REMOTE_STORAGE_PATH = os.path.join(BASE_DIR, 'media', 'remote_storage')
 
 # Because forms are input as lists by Django, all attributes here need to be
 # list like as well. The MultiValueDict/QueryDict get method assumes a list and

--- a/wooey/tests/config.py
+++ b/wooey/tests/config.py
@@ -2,10 +2,13 @@ from __future__ import unicode_literals
 import os
 
 from django.core.files import File
+from django.conf import settings
 
 BASE_DIR = os.path.split(__file__)[0]
 WOOEY_TEST_SCRIPTS = os.path.join(BASE_DIR, 'scripts')
 WOOEY_TEST_DATA = os.path.join(BASE_DIR, 'data')
+WOOEY_TEST_REMOTE_STORAGE_DIR = 'remote_storage'
+WOOEY_TEST_REMOTE_STORAGE_PATH = os.path.join(settings.MEDIA_ROOT, 'remote_storage')
 
 # Because forms are input as lists by Django, all attributes here need to be
 # list like as well. The MultiValueDict/QueryDict get method assumes a list and

--- a/wooey/tests/mixins.py
+++ b/wooey/tests/mixins.py
@@ -1,8 +1,10 @@
 import shutil
+import os
 
 from ..models import Script, WooeyFile, WooeyJob
 from ..backend import utils
 from .. import settings as wooey_settings
+from . import factories, config
 
 
 class FileCleanupMixin(object):
@@ -30,3 +32,8 @@ class ScriptFactoryMixin(object):
             path += 'c' # handle pyc junk
             utils.get_storage().delete(path)
         super(ScriptFactoryMixin, self).tearDown()
+
+    def setUp(self):
+        self.translate_script = factories.generate_script(os.path.join(config.WOOEY_TEST_SCRIPTS, 'translate.py'))
+        self.choice_script = factories.generate_script(os.path.join(config.WOOEY_TEST_SCRIPTS, 'choices.py'))
+        super(ScriptFactoryMixin, self).setUp()

--- a/wooey/tests/mixins.py
+++ b/wooey/tests/mixins.py
@@ -2,12 +2,16 @@ import shutil
 
 from ..models import Script, WooeyFile, WooeyJob
 from ..backend import utils
+from .. import settings as wooey_settings
 
 
 class FileCleanupMixin(object):
     def tearDown(self):
         for i in WooeyFile.objects.all():
-            utils.get_storage().delete(i.filepath.path)
+            path = i.filepath.name
+            utils.get_storage().delete(path)
+            if wooey_settings.WOOEY_EPHEMERAL_FILES:
+                utils.get_storage(local=False).delete(path)
         # delete job dirs
         local_storage = utils.get_storage(local=True)
         for i in WooeyJob.objects.all():
@@ -18,8 +22,11 @@ class FileCleanupMixin(object):
 class ScriptFactoryMixin(object):
     def tearDown(self):
         for i in Script.objects.all():
-            path = i.script_path.path
+            path = i.script_path.name
+            # import pdb; pdb.set_trace();
             utils.get_storage().delete(path)
+            if wooey_settings.WOOEY_EPHEMERAL_FILES:
+                utils.get_storage(local=False).delete(path)
             path += 'c' # handle pyc junk
             utils.get_storage().delete(path)
         super(ScriptFactoryMixin, self).tearDown()

--- a/wooey/tests/test_forms.py
+++ b/wooey/tests/test_forms.py
@@ -17,7 +17,7 @@ class FormTestCase(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase)
         return MultiValueDict(data)
 
     def test_master_form(self):
-        script = factories.TranslateScriptFactory()
+        script = self.translate_script
         form = utils.get_master_form(model=script)
         self.assertTrue(isinstance(form, WooeyForm))
         qdict = self.get_mvdict(config.SCRIPT_DATA['translate'].get('data'))
@@ -26,12 +26,12 @@ class FormTestCase(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase)
         self.assertTrue(form.is_valid())
 
     def test_group_form(self):
-        script = factories.TranslateScriptFactory()
+        script = self.translate_script
         form = utils.get_form_groups(model=script)
         self.assertEqual(len(form['groups']), 1)
 
     def test_multiplechoice_form(self):
-        script = factories.ChoiceScriptFactory()
+        script = self.choice_script
         form = utils.get_master_form(model=script)
         # check our wrapper is in the form render
         form_str = str(form)

--- a/wooey/tests/test_forms.py
+++ b/wooey/tests/test_forms.py
@@ -13,7 +13,7 @@ from . import mixins
 class FormTestCase(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
     @staticmethod
-    def get_mvdict( data):
+    def get_mvdict(data):
         return MultiValueDict(data)
 
     def test_master_form(self):
@@ -50,3 +50,4 @@ class FormTestCase(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase)
         file_param = 'multiple_file_choices'
         files = [i.value for i in job.get_parameters() if i.parameter.slug == file_param]
         self.assertEqual(len(files), len(fdict.get(file_param)))
+

--- a/wooey/tests/test_models.py
+++ b/wooey/tests/test_models.py
@@ -44,10 +44,10 @@ class ScriptGroupTestCase(TestCase):
 class TestJob(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
     urls = 'wooey.test_urls'
 
-    def setUp(self):
-        from .. import settings
-        # the test server doesn't have celery running
-        settings.WOOEY_CELERY = False
+    def get_local_url(self, fileinfo):
+        from ..backend import utils
+        local_storage = utils.get_storage(local=True)
+        return local_storage.url(fileinfo['object'].filepath.name)
 
     def test_jobs(self):
         script = factories.TranslateScriptFactory()
@@ -75,7 +75,8 @@ class TestJob(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         file_previews = utils.get_file_previews(job)
         for group, files in file_previews.items():
             for fileinfo in files:
-                response = Client().get(fileinfo.get('url'))
+                # for testing, we use the local url
+                response = Client().get(self.get_local_url(fileinfo))
                 self.assertEqual(response.status_code, 200)
 
         # check our download links are ok
@@ -87,7 +88,7 @@ class TestJob(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         file_previews = utils.get_file_previews(job)
         for group, files in file_previews.items():
             for fileinfo in files:
-                response = Client().get(fileinfo.get('url'))
+                response = Client().get(self.get_local_url(fileinfo))
                 self.assertEqual(response.status_code, 200)
 
     def test_multiplechoices(self):

--- a/wooey/tests/test_models.py
+++ b/wooey/tests/test_models.py
@@ -7,12 +7,10 @@ from .. import version
 
 class ScriptTestCase(mixins.ScriptFactoryMixin, TestCase):
 
-    def test_script_creation(self):
-        script = factories.TranslateScriptFactory()
 
     def test_multiple_choices(self):
         # load our choice script
-        script = factories.ChoiceScriptFactory()
+        script = self.choice_script
 
         multiple_choice_param = 'two_choices'
         single_choice_param = 'one_choice'
@@ -50,7 +48,7 @@ class TestJob(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         return local_storage.url(fileinfo['object'].filepath.name)
 
     def test_jobs(self):
-        script = factories.TranslateScriptFactory()
+        script = self.translate_script
         from ..backend import utils
         job = utils.create_wooey_job(script_pk=script.pk, data={'job_name': 'abc', 'sequence': 'aaa', 'out': 'abc'})
         job = job.submit_to_celery()
@@ -92,7 +90,7 @@ class TestJob(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
                 self.assertEqual(response.status_code, 200)
 
     def test_multiplechoices(self):
-        script = factories.ChoiceScriptFactory()
+        script = self.choice_script
         choices = ['2', '1', '3']
         choice_param = 'two_choices'
 

--- a/wooey/tests/test_scripts.py
+++ b/wooey/tests/test_scripts.py
@@ -12,8 +12,7 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
 
     def test_command_order(self):
         script = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
-        new_file = utils.get_storage(local=True).save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script))
-        new_file = utils.get_storage(local=True).path(new_file)
+        new_file = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script))
         added, errors = utils.add_wooey_script(script=new_file, group=None)
         self.assertEqual(added, True, errors)
         job = utils.create_wooey_job(script_pk=1, data={'job_name': 'abc', 'link': 'alink', 'name': 'aname'})
@@ -28,14 +27,12 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
 
     def test_script_upgrade(self):
         script_path = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
-        new_file = utils.get_storage(local=True).save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
-        new_file = utils.get_storage(local=True).path(new_file)
+        new_file = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
         added, errors = utils.add_wooey_script(script=new_file, group=None)
         self.assertEqual(added, True, errors)
         # upgrade script
         script = Script.objects.get(pk=1)
-        new_script = utils.get_storage(local=True).save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
-        new_script = utils.get_storage(local=True).path(new_script)
+        new_script = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
         script.script_path = new_script
         # we are going to be cloning this, so we lose the old object
         old_pk, old_version = script.pk, script.script_version

--- a/wooey/tests/test_scripts.py
+++ b/wooey/tests/test_scripts.py
@@ -16,8 +16,8 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
     def test_command_order(self):
         script = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
         new_file = self.storage.save(self.filename_func('command_order.py'), open(script))
-        added, errors = utils.add_wooey_script(script=new_file, group=None)
-        self.assertEqual(added, True, errors)
+        res = utils.add_wooey_script(script=new_file, group=None)
+        self.assertEqual(res['valid'], True, res['errors'])
         job = utils.create_wooey_job(script_pk=1, data={'job_name': 'abc', 'link': 'alink', 'name': 'aname'})
         # These are positional arguments -- we DO NOT want them returning anything
         self.assertEqual(['', ''], [i.parameter.short_param for i in job.get_parameters()])
@@ -31,8 +31,8 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
     def test_script_upgrade(self):
         script_path = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
         new_file = self.storage.save(self.filename_func('command_order.py'), open(script_path))
-        added, errors = utils.add_wooey_script(script=new_file, group=None)
-        self.assertEqual(added, True, errors)
+        res = utils.add_wooey_script(script=new_file, group=None)
+        self.assertEqual(res['valid'], True, res['errors'])
         # upgrade script
         script = Script.objects.get(pk=1)
         new_script = self.storage.save(self.filename_func('command_order.py'), open(script_path))

--- a/wooey/tests/test_scripts.py
+++ b/wooey/tests/test_scripts.py
@@ -9,10 +9,13 @@ from ..models import Script
 from .. import settings as wooey_settings
 
 class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
+    def setUp(self):
+        self.storage = utils.get_storage(local=not wooey_settings.WOOEY_EPHEMERAL_FILES)
+        self.filename_func = lambda x: os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, x)
 
     def test_command_order(self):
         script = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
-        new_file = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script))
+        new_file = self.storage.save(self.filename_func('command_order.py'), open(script))
         added, errors = utils.add_wooey_script(script=new_file, group=None)
         self.assertEqual(added, True, errors)
         job = utils.create_wooey_job(script_pk=1, data={'job_name': 'abc', 'link': 'alink', 'name': 'aname'})
@@ -27,12 +30,12 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, TestCase):
 
     def test_script_upgrade(self):
         script_path = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')
-        new_file = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
+        new_file = self.storage.save(self.filename_func('command_order.py'), open(script_path))
         added, errors = utils.add_wooey_script(script=new_file, group=None)
         self.assertEqual(added, True, errors)
         # upgrade script
         script = Script.objects.get(pk=1)
-        new_script = utils.get_storage().save(os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, 'command_order.py'), open(script_path))
+        new_script = self.storage.save(self.filename_func('command_order.py'), open(script_path))
         script.script_path = new_script
         # we are going to be cloning this, so we lose the old object
         old_pk, old_version = script.pk, script.script_version

--- a/wooey/tests/test_utils.py
+++ b/wooey/tests/test_utils.py
@@ -26,7 +26,7 @@ class TestUtils(mixins.ScriptFactoryMixin, TestCase):
         from .. import settings as wooey_settings
         from django.contrib.auth.models import AnonymousUser
         user = AnonymousUser()
-        script = factories.TranslateScriptFactory()
+        script = self.translate_script
         d = utils.valid_user(script, user)
         self.assertTrue(d['valid'])
         wooey_settings.WOOEY_ALLOW_ANONYMOUS = False
@@ -35,7 +35,7 @@ class TestUtils(mixins.ScriptFactoryMixin, TestCase):
 
     def test_valid_user(self):
         user = factories.UserFactory()
-        script = factories.TranslateScriptFactory()
+        script = self.translate_script
         d = utils.valid_user(script, user)
         self.assertTrue(d['valid'])
         from .. import settings as wooey_settings

--- a/wooey/tests/test_views.py
+++ b/wooey/tests/test_views.py
@@ -154,7 +154,7 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         # test submitting this in the 'currently' field
         from ..models import WooeyJob
         job = WooeyJob.objects.latest('created_date')
-        files = [i.value.path for i in job.get_parameters() if i.parameter.slug == 'multiple_file_choices']
+        files = [i.value.name for i in job.get_parameters() if i.parameter.slug == 'multiple_file_choices']
 
         data['multiple_file_choices'] = files
         request = self.factory.post(url, data=data)

--- a/wooey/tests/test_views.py
+++ b/wooey/tests/test_views.py
@@ -21,6 +21,7 @@ def load_JSON_dict(d):
 
 class CeleryViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
     def setUp(self):
+        super(CeleryViews, self).setUp()
         self.factory = RequestFactory()
         # the test server doesn't have celery running
         settings.WOOEY_CELERY = False
@@ -34,7 +35,8 @@ class CeleryViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         self.assertEqual({u'items': {u'global': [], u'results': [], u'user': []},
                           u'totals': {u'global': 0, u'results': 0, u'user': 0}
                             }, json.loads(d))
-        job = factories.TranslateJobFactory()
+
+        job = factories.generate_job(self.translate_script)
         job.save()
         response = wooey_celery.all_queues_json(request)
         d = json.loads(response.content.decode("utf-8"))
@@ -57,7 +59,7 @@ class CeleryViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
     def test_celery_commands(self):
         user = factories.UserFactory()
-        job = factories.TranslateJobFactory()
+        job = factories.generate_job(self.translate_script)
         job.user = user
         job.save()
         celery_command = {'celery-command': ['delete'], 'job-id': [job.pk]}
@@ -89,7 +91,7 @@ class CeleryViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
     def test_celery_task_view(self):
         user = factories.UserFactory()
-        job = factories.TranslateJobFactory()
+        job = factories.generate_job(self.translate_script)
         job.user = user
         job.save()
 
@@ -117,6 +119,7 @@ class CeleryViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
 class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
     def setUp(self):
+        super(WooeyViews, self).setUp()
         self.factory = RequestFactory()
         self.script_view_func = wooey_views.WooeyScriptJSON.as_view()
         # the test server doesn't have celery running
@@ -124,7 +127,7 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
     def test_multiple_choice_clone(self):
         from ..backend import utils
-        script = factories.ChoiceScriptFactory()
+        script = self.choice_script
         choices = ['2', '1', '3']
         choice_param = 'two_choices'
         job = utils.create_wooey_job(script_pk=script.pk, data={'job_name': 'abc', choice_param: choices, 'wooey_type': script.pk})
@@ -137,7 +140,7 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
 
     def test_multiple_choice(self):
         user = factories.UserFactory()
-        script = factories.ChoiceScriptFactory()
+        script = self.choice_script
         url = reverse('wooey:wooey_script', kwargs={'slug': script.slug})
         data = {'job_name': 'abc', 'wooey_type': script.pk, 'two_choices': ['2', '1', '3']}
         filecount = 0

--- a/wooey/wooeystorage.py
+++ b/wooey/wooeystorage.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
+import os
+
 from boto.utils import parse_ts
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import get_storage_class, FileSystemStorage
 from storages.backends.s3boto import S3BotoStorage
 
 from . import settings as wooey_settings
@@ -11,6 +13,7 @@ from . import settings as wooey_settings
 class CachedS3BotoStorage(S3BotoStorage):
     def __init__(self, *args, **kwargs):
         super(CachedS3BotoStorage, self).__init__(*args, **kwargs)
+        self._modified = False
         self.local_storage = get_storage_class('django.core.files.storage.FileSystemStorage')()
 
     def _open(self, name, mode='rb'):
@@ -26,6 +29,36 @@ class CachedS3BotoStorage(S3BotoStorage):
             entry = self.bucket.get_key(self._encode_name(name))
         # Parse the last_modified string to a local datetime object.
         return parse_ts(entry.last_modified)
+
+    def path(self, name):
+        return self.local_storage.path(name)
+
+    def delete(self, name):
+        # we have to remove the name from the _entries cache or else deleted files will persist in our cache
+        # and give false information
+        super(CachedS3BotoStorage, self).delete(name)
+        name = self._normalize_name(self._clean_name(name))
+        self._entries.pop(name, None)
+        self._modified = True
+
+    @property
+    def entries(self):
+        """
+        Get the locally cached files for the bucket.
+        """
+        if self.preload_metadata and (self._modified or not self._entries):
+            self._entries = dict((self._decode_name(entry.key), entry)
+                                for entry in self.bucket.list(prefix=self.location))
+            self._modified = True
+        return self._entries
+
+
+class FakeRemoteStorage(FileSystemStorage):
+    def __init__(self, *args, **kwargs):
+        from .tests.config import WOOEY_TEST_REMOTE_STORAGE
+        kwargs['location'] = WOOEY_TEST_REMOTE_STORAGE
+        super(FakeRemoteStorage, self).__init__(*args, **kwargs)
+        self.local_storage = get_storage_class('django.core.files.storage.FileSystemStorage')()
 
     def path(self, name):
         return self.local_storage.path(name)

--- a/wooey/wooeystorage.py
+++ b/wooey/wooeystorage.py
@@ -46,10 +46,7 @@ class CachedS3BotoStorage(S3BotoStorage):
 
 class FakeRemoteStorage(FileSystemStorage):
     def __init__(self, *args, **kwargs):
-        from .tests.config import WOOEY_TEST_REMOTE_STORAGE_PATH
-        kwargs['location'] = WOOEY_TEST_REMOTE_STORAGE_PATH
+        from .tests import config
+        kwargs['location'] = config.WOOEY_TEST_REMOTE_STORAGE_PATH
         super(FakeRemoteStorage, self).__init__(*args, **kwargs)
         self.local_storage = get_storage_class('django.core.files.storage.FileSystemStorage')()
-
-    def path(self, name):
-        return self.local_storage.path(name)


### PR DESCRIPTION
This addresses several issues with ephemeral file systems:

It adds tests for S3 and a fake remote storage engine.
It uses django-storages-redux, which is a python3 compatible version of django-storages.
It paths a bug in django-storages-redux with preloading metadata from S3.
It changes the logic of adding new scripts, and uses signals instead of the save method. It's not perfect yet, but it's less tortured than the previous implementation.
It fixes a host of issues with remote storage like file system cleanup.
