### PR TITLE
bugfix for typo

### DIFF
--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -89,10 +89,8 @@ class WooeyFormFactory(object):
         if form_field == 'FileField':
             if param.is_output:
                 form_field = 'CharField'
-        if form_field == 'FieldField':
-            if param.is_output:
                 initial = None
-            elif list(filter(None, initial)): # for python3, we need to evaluate the filter object
+            elif initial is not None and list(filter(None, initial)): # for python3, we need to evaluate the filter object
                 if isinstance(initial, (list, tuple)):
                     initial = [utils.get_storage_object(value) if not hasattr(value, 'path') else value for value in initial if value is not None]
                 else:


### PR DESCRIPTION
This bug has been in since 

https://github.com/wooey/Wooey/commit/f7ec406ef9cae46715272a7e046fb4bab58f3bc7#diff-f7feac6cc2da4411bac06a8708bbdbff

Where a typo resulted in FileField becoming FieldField. To avoid this, we should eventually migrate to having all these defined as variables, so any typos will crash the program instead of being silent.