### PR TITLE
Multi values input fixes

### DIFF
--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -75,10 +75,10 @@ def get_job_commands(job=None):
         if subproc_value:
             param_dict[subproc_param].append(subproc_value)
     for param, values in param_dict.items():
-        if param:
-            com.extend([param])
-        if values:
-            com.extend(values)
+        for value in values:
+            if param:
+                com.append(param)
+            com.append(value)
     return com
 
 

--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -3,6 +3,7 @@ __author__ = 'chris'
 import copy
 import json
 import six
+import os
 from collections import OrderedDict
 
 from django import forms
@@ -89,14 +90,18 @@ class WooeyFormFactory(object):
         if form_field == 'FileField':
             if param.is_output:
                 form_field = 'CharField'
-                initial = None
+                if initial:
+                    if not isinstance(initial, (list, tuple)):
+                        initial = [initial]
+                    initial = [os.path.split(i.name)[1] for i in initial]
             elif initial is not None and list(filter(None, initial)): # for python3, we need to evaluate the filter object
                 if isinstance(initial, (list, tuple)):
                     initial = [utils.get_storage_object(value) if not hasattr(value, 'path') else value for value in initial if value is not None]
                 else:
                     initial = utils.get_storage_object(initial) if not hasattr(initial, 'path') else initial
                 field_kwargs['widget'] = forms.ClearableFileInput()
-        # if not isinstance(initial, (list, tuple)):
+        if not multiple_choices and isinstance(initial, list):
+            initial = initial[0]
         field_kwargs['initial'] = initial
         field = getattr(forms, form_field)
         field = field(**field_kwargs)

--- a/wooey/models/core.py
+++ b/wooey/models/core.py
@@ -306,7 +306,6 @@ class ScriptParameters(WooeyPy2Mixin, models.Model):
                 return com
         if field == self.FILE:
             if self.parameter.is_output:
-
                 try:
                     value = value.path
                 except AttributeError:

--- a/wooey/tests/scripts/multi_output.py
+++ b/wooey/tests/scripts/multi_output.py
@@ -1,0 +1,9 @@
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description="Something")
+parser.add_argument("--output_filename", type=argparse.FileType('w'), required=True, help="Name of Excel output file.", nargs='+')
+parser.add_argument("--due_date_field", type=str, help="Column name for due date field. 'Due Date' by default.")
+
+if __name__ == '__main__':
+    args = parser.parse_args()


### PR DESCRIPTION
This addresses issue #50. It also changes how we were dealing with multiple inputs on the command line. It now iterates each parameter/value instead of just listing all the values after the parameter. The latter approach fails for cases like argparse.FileType('w').