### PR TITLE
Add script `documentation` field to hold longer script docs.

### DIFF
--- a/wooey/migrations/0007_script_documentation.py
+++ b/wooey/migrations/0007_script_documentation.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wooey', '0006_script_group_defaults'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='script',
+            name='documentation',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/wooey/models/core.py
+++ b/wooey/models/core.py
@@ -58,6 +58,7 @@ class Script(ModelDiffMixin, WooeyPy2Mixin, models.Model):
     # or else we will fail form validation before we hit the model.
     script_group = models.ForeignKey('ScriptGroup', null=True, blank=True)
     script_description = models.TextField(blank=True, null=True)
+    documentation = models.TextField(blank=True, null=True)
     script_order = models.PositiveSmallIntegerField(default=1)
     is_active = models.BooleanField(default=True)
     user_groups = models.ManyToManyField(Group, blank=True)

--- a/wooey/templates/wooey/base.html
+++ b/wooey/templates/wooey/base.html
@@ -455,6 +455,7 @@
     <script type="text/javascript" src="//cdn.datatables.net/1.10.6/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="//cdn.datatables.net/responsive/1.0.5/js/dataTables.responsive.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/showdown/1.2.2/showdown.min.js"></script>
     {% endblock js %}
 
     {% block extra_js %}
@@ -707,6 +708,10 @@
             return false;
             }
 
+        var converter = new showdown.Converter({
+            'github_flavouring': true,
+            'tables': true
+        });
 
         $(document).ready(function(){
 
@@ -774,6 +779,10 @@
 
 
             }, 100);
+
+            $(".markdown").each(function( index ) {
+                $( this ).html( converter.makeHtml( $( this ).html() ) );
+            });
 
 
 

--- a/wooey/templates/wooey/scripts/script_view.html
+++ b/wooey/templates/wooey/scripts/script_view.html
@@ -20,7 +20,7 @@
 
         {% if script.documentation %}
         <div class="panel panel-default">
-            <div class="panel-heading">Documentation  <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-metadata" href="#collapse-metadata"></a></div>
+            <div class="panel-heading">{% trans "Documentation" %} <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-metadata" href="#collapse-metadata"></a></div>
             <div id="collapse-metadata" class="panel-collapse collapse in">
             <div class="panel-body markdown">{{ script.documentation }}</div>
             </div>
@@ -32,7 +32,7 @@
         {% csrf_token %}
 
         <div class="panel panel-default">
-        <div class="panel-heading">Settings  <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-settings" href="#collapse-settings"></a></div>
+        <div class="panel-heading">{% trans "Settings" %} <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-settings" href="#collapse-settings"></a></div>
 
         <div id="collapse-settings" class="panel-collapse collapse in">
 
@@ -79,17 +79,17 @@
 
 
         <div class="panel panel-default">
-            <div class="panel-heading">Metadata  <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-metadata" href="#collapse-metadata"></a></div>
+            <div class="panel-heading">{% trans "Metadata" %} <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-metadata" href="#collapse-metadata"></a></div>
             <div id="collapse-metadata" class="panel-collapse collapse in">
             <div class="panel-body">
 
                 <div class="form-group row">
                     <label for="job-name">{% trans "Job Name" %}</label>
-                    <input class="form-control" id="wooey_job_name" type="text" name="job_name" placeholder="{% trans "Job Name" %}" value="{{ script.script_name }} {% now "Ymd-G:i" %}"/>
+                    <input class="form-control" id="wooey_job_name" type="text" id="job-name" name="job_name" placeholder="{% trans "Job Name" %}" value="{{ script.script_name }} {% now "Ymd-G:i" %}"/>
                 </div>
                 <div class="form-group row">
                     <label for="job-description">{% trans "Job Description" %}</label>
-                    <textarea class="form-control" id="wooey_job_description" cols="30" rows="5" name="job_description" placeholder="{% trans "Enter job description here..." %}"></textarea>
+                    <textarea class="form-control" id="wooey_job_description" cols="30" rows="5" id="job-description" name="job_description" placeholder="{% trans "Enter job description here..." %}"></textarea>
                 </div>
             </div>
             </div>

--- a/wooey/templates/wooey/scripts/script_view.html
+++ b/wooey/templates/wooey/scripts/script_view.html
@@ -18,6 +18,16 @@
 
   <div class="container-fluid">
 
+        {% if script.documentation %}
+        <div class="panel panel-default">
+            <div class="panel-heading">Documentation  <a class="icon icon-collapse" data-toggle="collapse" data-target="#collapse-metadata" href="#collapse-metadata"></a></div>
+            <div id="collapse-metadata" class="panel-collapse collapse in">
+            <div class="panel-body markdown">{{ script.documentation }}</div>
+            </div>
+        </div>
+        {% endif %}
+
+
     <form id="wooey-job-form" method="POST" action="{{ form.action }}" enctype="multipart/form-data">
         {% csrf_token %}
 


### PR DESCRIPTION
This adds support for longer documentation for scripts using a
`documentation` field. The Javascript ShowDown markdown converted
is used to render markdown on the client side to avoid dependencies
for the installation.