### PR TITLE
Add support for disabling registration url link in template

### DIFF
--- a/wooey/templates/wooey/registration/login_header.html
+++ b/wooey/templates/wooey/registration/login_header.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load wooey_tags %}
 <form class="navbar-form" method="post" action="{% url 'wooey:wooey_login' %}">
     {% csrf_token %}
   <div class="form-group form-group-sm">
@@ -9,6 +10,9 @@
   </div>
     <input type="hidden" name="next" value="{{ request.path }}" />
   <button type="submit" class="btn btn-default btn-sm" id="wooey-login">{% trans "Login" %}</button>
+{% get_wooey_setting "WOOEY_REGISTER_URL" as registration_url %}
+{% if registration_url %}
 {#    This is a hack but it gets register aligned properly without any work#}
     <div class="form-group"><li>&nbsp;&nbsp;<a href="{% url "wooey:wooey_register" %}">{% trans "Register" %}</a></li></div>
+{% endif %}
 </form>

--- a/wooey/templatetags/wooey_tags.py
+++ b/wooey/templatetags/wooey_tags.py
@@ -3,11 +3,74 @@ from django import template
 from .. import settings as wooey_settings
 from django.utils.safestring import mark_safe
 from django.contrib.contenttypes.models import ContentType
+from django.template.base import TemplateSyntaxError, TagHelperNode, parse_bits
+
+from inspect import getargspec
 import urllib
 import hashlib
 
+class Library(template.Library):
+    def simple_assignment_tag(self, func=None, takes_context=None, name=None):
+        '''
+        Like assignment_tag but when "as" not provided, falls back to simple_tag behavior!
+        NOTE: this is based on Django's assignment_tag implementation, modified as needed.
 
-register = template.Library()
+        https://gist.github.com/natevw/f14812604be62c073461
+        '''
+
+        # (nvw) imports necessary to match original context
+
+        def dec(func):
+            params, varargs, varkw, defaults = getargspec(func)
+
+            # (nvw) added from Django's simple_tag implementation
+            class SimpleNode(TagHelperNode):
+                def render(self, context):
+                    resolved_args, resolved_kwargs = self.get_resolved_arguments(context)
+                    return func(*resolved_args, **resolved_kwargs)
+
+            class AssignmentNode(TagHelperNode):
+                def __init__(self, takes_context, args, kwargs, target_var):
+                    super(AssignmentNode, self).__init__(takes_context, args, kwargs)
+                    self.target_var = target_var
+
+                def render(self, context):
+                    resolved_args, resolved_kwargs = self.get_resolved_arguments(context)
+                    context[self.target_var] = func(*resolved_args, **resolved_kwargs)
+                    return ''
+
+            function_name = (name or
+                getattr(func, '_decorated_function', func).__name__)
+
+            def compile_func(parser, token):
+                bits = token.split_contents()[1:]
+                if len(bits) > 2 and bits[-2] == 'as':
+                    target_var = bits[-1]
+                    bits = bits[:-2]
+                    args, kwargs = parse_bits(parser, bits, params,
+                        varargs, varkw, defaults, takes_context, function_name)
+                    return AssignmentNode(takes_context, args, kwargs, target_var)
+                else:
+                    args, kwargs = parse_bits(parser, bits, params,
+                        varargs, varkw, defaults, takes_context, function_name)
+                    return SimpleNode(takes_context, args, kwargs)
+
+            compile_func.__doc__ = func.__doc__
+            self.tag(function_name, compile_func)
+            return func
+
+        if func is None:
+            # @register.assignment_tag(...)
+            return dec
+        elif callable(func):
+            # @register.assignment_tag
+            return dec(func)
+        else:
+            raise TemplateSyntaxError("Invalid arguments provided to assignment_tag")
+
+register = Library()
+
+
 @register.simple_tag
 def get_user_favorite_count(user, app, model):
     from ..models import Favorite
@@ -16,7 +79,7 @@ def get_user_favorite_count(user, app, model):
     favorites_count = Favorite.objects.filter(content_type=ctype, user=user).count()
     return str(favorites_count)
 
-@register.simple_tag
+@register.simple_assignment_tag
 def get_wooey_setting(name):
     return getattr(wooey_settings, name, "")
 


### PR DESCRIPTION
A bit more complicated than expected. In order to test the state of the setting we need to pull it into the template context, which means having an assignment tag, e.g. get_wooey_setting <name> as <variable>

Django has a simple helper function for simple tag and assignment tags, but not a combination. An implementation of this has been added from: https://gist.github.com/natevw/f14812604be62c073461

This is supported natively via `simple_tag` in the [development version of Django](https://docs.djangoproject.com/en/dev/howto/custom-template-tags/#django.template.Library.simple_tag) (1.9) but this approach allows us backwards compatibility for the time being. It's also possible to implement this without the helper but it's nicer and cleaner to have the reusable wrapper.

With this we can now do both:

    {% get_wooey_setting WOOEY_REGISTER_URL %}
    {% get_wooey_setting WOOEY_REGISTER_URL as register_url %}

...with the former outputting the URL, the latter assigning to variable. This is similar in practise to the Django url tag.

Checking on license for the include.