### PR TITLE
Job UUIDs for private URLs and public access

### DIFF
--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import six
+import uuid
 import traceback
 from operator import itemgetter
 from collections import OrderedDict, defaultdict

--- a/wooey/migrations/0009_wooeyjob_uuid.py
+++ b/wooey/migrations/0009_wooeyjob_uuid.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuid, os
+
+def gen_uuid(apps, schema_editor):
+    WooeyJob = apps.get_model('wooey', 'WooeyJob')
+    for obj in WooeyJob.objects.all():
+        obj.uuid = uuid.uuid4()
+        obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wooey', '0008_short_param_admin'),
+    ]
+
+    operations = [
+        # Add the uuid field with unique=False for existing entries
+        # due to a bug in migrations this will set all to the same uuid
+        migrations.AddField(
+            model_name='wooeyjob',
+            name='uuid',
+            field=models.CharField(default=uuid.uuid4, unique=False, max_length=255),
+        ),
+        # Set the uuids for existing records
+        migrations.RunPython(gen_uuid, reverse_code=migrations.RunPython.noop),
+        # Set to unique=True 
+        migrations.AlterField(
+            model_name='wooeyjob',
+            name='uuid',
+            field=models.CharField(default=uuid.uuid4, unique=True, max_length=255),
+        ),
+    ]
+

--- a/wooey/migrations/0012_wooeyjob_uuid.py
+++ b/wooey/migrations/0012_wooeyjob_uuid.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             field=models.CharField(default=uuid.uuid4, unique=False, max_length=255),
         ),
         # Set the uuids for existing records
-        migrations.RunPython(gen_uuid, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(gen_uuid),
         # Set to unique=True 
         migrations.AlterField(
             model_name='wooeyjob',

--- a/wooey/migrations/0012_wooeyjob_uuid.py
+++ b/wooey/migrations/0012_wooeyjob_uuid.py
@@ -14,7 +14,7 @@ def gen_uuid(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wooey', '0008_short_param_admin'),
+        ('wooey', '0011_script_versioning_cleanup'),
     ]
 
     operations = [

--- a/wooey/migrations/0012_wooeyjob_uuid.py
+++ b/wooey/migrations/0012_wooeyjob_uuid.py
@@ -2,13 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import uuid, os
-
-def gen_uuid(apps, schema_editor):
-    WooeyJob = apps.get_model('wooey', 'WooeyJob')
-    for obj in WooeyJob.objects.all():
-        obj.uuid = uuid.uuid4()
-        obj.save()
+import uuid
 
 
 class Migration(migrations.Migration):
@@ -24,14 +18,6 @@ class Migration(migrations.Migration):
             model_name='wooeyjob',
             name='uuid',
             field=models.CharField(default=uuid.uuid4, unique=False, max_length=255),
-        ),
-        # Set the uuids for existing records
-        migrations.RunPython(gen_uuid),
-        # Set to unique=True 
-        migrations.AlterField(
-            model_name='wooeyjob',
-            name='uuid',
-            field=models.CharField(default=uuid.uuid4, unique=True, max_length=255),
         ),
     ]
 

--- a/wooey/migrations/0013_wooeyjob_uuid_populate.py
+++ b/wooey/migrations/0013_wooeyjob_uuid_populate.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuid
+
+
+def gen_uuid(apps, schema_editor):
+    WooeyJob = apps.get_model('wooey', 'WooeyJob')
+    for obj in WooeyJob.objects.all():
+        obj.uuid = uuid.uuid4()
+        obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wooey', '0012_wooeyjob_uuid'),
+    ]
+
+    operations = [
+        # Set the uuids for existing records
+        migrations.RunPython(gen_uuid),
+    ]
+

--- a/wooey/migrations/0014_wooeyjob_uuid_finalise.py
+++ b/wooey/migrations/0014_wooeyjob_uuid_finalise.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wooey', '0013_wooeyjob_uuid_populate'),
+    ]
+
+    operations = [
+        # Set to unique=True
+        migrations.AlterField(
+            model_name='wooeyjob',
+            name='uuid',
+            field=models.CharField(default=uuid.uuid4, unique=True, max_length=255),
+        ),
+    ]
+

--- a/wooey/models/core.py
+++ b/wooey/models/core.py
@@ -5,6 +5,7 @@ import errno
 import importlib
 import json
 import six
+import uuid
 from io import IOBase
 
 from django.core.files.storage import default_storage
@@ -128,6 +129,7 @@ class WooeyJob(WooeyPy2Mixin, models.Model):
     # blank=True, null=True is to allow anonymous users to submit jobs
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
     celery_id = models.CharField(max_length=255, null=True)
+    uuid = models.CharField(max_length=255, default=uuid.uuid4, unique=True)
     job_name = models.CharField(max_length=255)
     job_description = models.TextField(null=True, blank=True)
     stdout = models.TextField(null=True, blank=True)
@@ -196,8 +198,10 @@ class WooeyJob(WooeyPy2Mixin, models.Model):
 
     @property
     def output_path(self):
-        return os.path.join(wooey_settings.WOOEY_FILE_DIR, get_valid_filename(self.user.username if self.user is not None else ''),
-                            get_valid_filename(self.script_version.script.slug if not self.script_version.script.save_path else self.script_version.script.save_path), str(self.pk))
+        return os.path.join(wooey_settings.WOOEY_FILE_DIR,
+                            get_valid_filename(self.user.username if self.user is not None else ''),
+                            get_valid_filename(self.script_version.script.slug if not self.script_version.script.save_path else self.script_version.script.save_path),
+                            str(self.uuid))
 
     def get_output_path(self):
         path = self.output_path

--- a/wooey/models/core.py
+++ b/wooey/models/core.py
@@ -172,6 +172,7 @@ class WooeyJob(WooeyPy2Mixin, models.Model):
             self.user = None if user is None or not user.is_authenticated() else user
             # clear the output channels
             self.celery_id = None
+            self.uuid = uuid.uuid4()
             self.stdout = ''
             self.stderr = ''
             self.save()

--- a/wooey/templates/wooey/jobs/job_view.html
+++ b/wooey/templates/wooey/jobs/job_view.html
@@ -52,6 +52,8 @@
 
             <div class="btn-group">
             <a href="{{ job_info.archives.0.url }}" role="button" class="btn btn-success">
+            {% url 'wooey:celery_results_uuid' job_info.job.uuid as permalink %}
+            {% absolute_url permalink as permalink %}
             <span class="glyphicon glyphicon-share" aria-hidden="true"></span> {% trans "Share" %}
             </a>
             <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -60,17 +62,14 @@
             </button>
             <ul class="dropdown-menu" role="menu">
                 <!-- <li><a href="""><span class="glyphicon glyphicon-figshare"></span> Figshare</a></li> -->
-                {% with request.build_absolute_uri as permalink %}
                 <li><a href="{{ permalink }}" onclick="$('#modal-permalink').modal(); return false;"><span class="glyphicon glyphicon-link"></span> Permalink</a></li>
-                {% endwith %}
-                <li><a href="mailto:?subject=Wooey Job #{{ job_info.job.id }} is {{ job_info.job.status }}&body=You can see the result and any outputs at the following link:%0D%0A{{ request.build_absolute_uri }}"><span class="glyphicon glyphicon-envelope"></span> Email</a></li>
+
+                <li><a href="mailto:?subject=Wooey Job #{{ job_info.job.id }} is {{ job_info.job.status }}&body=You can see the result and any outputs at the following link:%0D%0A{{ permalink }}"><span class="glyphicon glyphicon-envelope"></span> Email</a></li>
             </ul>
             </div>
 
 
-        {% with request.build_absolute_uri as permalink %}
-        {% include 'wooey/modals/permalink_modal.html' %}
-        {% endwith %}
+    {% include 'wooey/modals/permalink_modal.html' %}
 
 
         {% endif %}

--- a/wooey/templates/wooey/modals/permalink_modal.html
+++ b/wooey/templates/wooey/modals/permalink_modal.html
@@ -5,6 +5,6 @@
 {% block modal_body %}
 <p>{% trans "You can share the following link to give open access to your results:" %}</p>
 <p><a href="{{ permalink }}">{{ permalink }}</a></p>
-<p>Note that anyone with this link will be able to view your data — only share with people you trust! If you
-want to give more restricted access, use user-by-user sharing.</p>
+<p>Anyone with this link will be able to view your data — only share with people you trust! <!-- If you
+want to give more restricted access, use user-by-user sharing.--></p>
 {% endblock modal_body %}

--- a/wooey/templatetags/wooey_tags.py
+++ b/wooey/templatetags/wooey_tags.py
@@ -171,3 +171,8 @@ def gravatar(parser, token):
 @register.filter
 def get_range(value):
     return range(int(value))
+
+@register.simple_assignment_tag(takes_context=True)
+def absolute_url(context, url):
+    request = context['request']
+    return request.build_absolute_uri(url)

--- a/wooey/tests/factories.py
+++ b/wooey/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 import os
 import six
+import uuid
 
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
@@ -40,7 +41,6 @@ class BaseJobFactory(factory.DjangoModelFactory):
         model = WooeyJob
     job_name = six.u('\xd0\xb9\xd1\x86\xd1\x83')
     job_description = six.u('\xd0\xb9\xd1\x86\xd1\x83\xd0\xb5\xd0\xba\xd0\xb5')
-
 
 def generate_script(script_path):
     filename = os.path.join(script_path)[1]

--- a/wooey/tests/test_models.py
+++ b/wooey/tests/test_models.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from django.test import TestCase, Client
 

--- a/wooey/urls.py
+++ b/wooey/urls.py
@@ -24,6 +24,11 @@ wooey_patterns = [
     url(r'^jobs/(?P<job_id>[0-9\-]+)/$', views.JobView.as_view(), name='celery_results'),
     url(r'^jobs/(?P<job_id>[0-9\-]+)/json$', views.JobJSON.as_view(), name='celery_results_json'),
 
+    # Global public access via uuid
+    url(r'^jobs/(?P<uuid>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12})/$', views.JobView.as_view(), name='celery_results_uuid'),
+    url(r'^jobs/(?P<uuid>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12})/json$', views.JobJSON.as_view(), name='celery_results_json_uuid'),
+
+
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/$', views.WooeyScriptView.as_view(), name='wooey_script'),
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>[\d+])$', views.WooeyScriptView.as_view(), name='wooey_script'),
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>\d+)/iteration/(?P<script_iteration>\d+)$', views.WooeyScriptView.as_view(), name='wooey_script'),

--- a/wooey/views/wooey_celery.py
+++ b/wooey/views/wooey_celery.py
@@ -145,9 +145,15 @@ class JobBase(DetailView):
     model = WooeyJob
 
     def get_object(self):
-        # FIXME: Update urls to use PK
-        self.kwargs['pk'] = self.kwargs.get('job_id')
-        return super(JobBase, self).get_object()
+
+        if 'uuid' in self.kwargs:
+            return self.model.objects.get(uuid=self.kwargs['uuid'])
+
+        else:
+            # FIXME: Update urls to use PK
+            self.kwargs['pk'] = self.kwargs.get('job_id')
+
+            return super(JobBase, self).get_object()
 
     def get_context_data(self, **kwargs):
         ctx = super(JobBase, self).get_context_data(**kwargs)
@@ -156,7 +162,10 @@ class JobBase(DetailView):
         user = self.request.user
         user = None if not user.is_authenticated() and wooey_settings.WOOEY_ALLOW_ANONYMOUS else user
         job_user = wooey_job.user
-        if job_user == None or job_user == user or (user != None and user.is_superuser):
+        if job_user is None or job_user == user or \
+                (user is not None and user.is_superuser) or \
+                ('uuid' in self.kwargs):
+
             out_files = get_file_previews(wooey_job)
             all = out_files.pop('all', [])
             archives = out_files.pop('archives', [])


### PR DESCRIPTION
Implements a per job UUID that creates secure folders for jobs and
outputs (unguessable) and allows for sharing of results via a
unique ID with public access.

Sharing and permalinks are implemented using this approach.

Previous jobs will be given a UUID for access but their folders
and files will remain in place.