### PR TITLE
fix for enforcing uniqueness of ScriptVersion default_version

### DIFF
--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -1,21 +1,11 @@
 from __future__ import absolute_import
+import os
+
 from django.contrib.admin import ModelAdmin, site, TabularInline
 from django.forms import ModelForm, ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from .models import Script, ScriptVersion, ScriptGroup, ScriptParameter, WooeyJob, ScriptParameterGroup, WooeyFile
-
-
-class ScriptVersionForm(ModelForm):
-    class Meta:
-        model = ScriptVersion
-        fields = '__all__'
-
-    def clean(self):
-        cleaned = self.cleaned_data
-        # make sure we only have 1 default
-        current_defaults = ScriptVersion.objects.filter(script=cleaned['script'], default_version=True)
-        current_defaults.update(default_version=False)
 
 
 class JobAdmin(ModelAdmin):
@@ -25,7 +15,6 @@ class JobAdmin(ModelAdmin):
 class ScriptVersionInline(TabularInline):
     model = ScriptVersion
     extra = 0
-    form = ScriptVersionForm
 
 
 class ScriptAdmin(ModelAdmin):
@@ -33,6 +22,9 @@ class ScriptAdmin(ModelAdmin):
     inlines = [
         ScriptVersionInline
     ]
+
+    class Media:
+        js = (os.path.join('wooey', 'js', 'admin', 'script.js'),)
 
 
 class ParameterAdmin(ModelAdmin):

--- a/wooey/static/wooey/js/admin/script.js
+++ b/wooey/static/wooey/js/admin/script.js
@@ -1,0 +1,23 @@
+var $ = django.jQuery;
+$(document).ready(function(){
+    var default_version_selector = '.field-default_version > input';
+    var $default_script_versions = $(default_version_selector);
+    $default_script_versions.click(function(event){
+        var $this = $(this);
+        var checked = $this.is(':checked');
+        if( checked === true){
+            // remove all other checks
+            $(default_version_selector).each(function(index, value){
+                if(value.id != $this.attr('id')){
+                    $(value).prop('checked', false)
+                }
+            });
+        }
+        else{
+            // if we are the sole check, do not remove it
+            if(!($(default_version_selector).is(':checked'))){
+                $this.prop('checked', true);
+            }
+        }
+    });
+});


### PR DESCRIPTION
This changes the default_version to rely on javascript to keep 1 version of default_version active at a time. We cannot rely on forms to do this correctly.