### PR TITLE
Script version url parsing

### DIFF
--- a/wooey/urls.py
+++ b/wooey/urls.py
@@ -30,8 +30,8 @@ wooey_patterns = [
 
 
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/$', views.WooeyScriptView.as_view(), name='wooey_script'),
-    url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>[\d+])$', views.WooeyScriptView.as_view(), name='wooey_script'),
-    url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>\d+)/iteration/(?P<script_iteration>\d+)$', views.WooeyScriptView.as_view(), name='wooey_script'),
+    url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>[A-Za-z\.0-9]+)$', views.WooeyScriptView.as_view(), name='wooey_script'),
+    url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/version/(?P<script_version>[A-Za-z\.0-9]+)/iteration/(?P<script_iteration>\d+)$', views.WooeyScriptView.as_view(), name='wooey_script'),
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/jobs/(?P<job_id>[a-zA-Z0-9\-]+)$', views.WooeyScriptView.as_view(), name='wooey_script_clone'),
     url(r'^scripts/(?P<slug>[a-zA-Z0-9\-\_]+)/$', views.WooeyScriptJSON.as_view(), name='wooey_script_json'),
 


### PR DESCRIPTION
This addresses the issue raised in #73. I tested with several variants such as:
1.0alpha, 0.1pre, 0.1, etc. I don't think spaces should be supported, but we may want to enforce that in our ScriptVersion code to fix any aspects of a script's version that doesn't conform (maybe replace spaces with dashes)