### PR TITLE
Fix for WOOEY_SHOW_LOCKED_SCRIPTS = False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='wooey',
-    version='0.2.6',
+    version='0.9.0',
     packages=find_packages(),
     scripts=['scripts/wooify'],
     entry_points={'console_scripts': ['wooify = wooey.backend.command_line:bootstrap', ]},

--- a/wooey/templates/wooey/scripts/script_panel.html
+++ b/wooey/templates/wooey/scripts/script_panel.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load wooey_tags %}
-
+{% get_wooey_setting "WOOEY_SHOW_LOCKED_SCRIPTS" as wooey_show_locked_scripts %}
+{% if script.is_active or wooey_show_locked_scripts %}
 <div class="col-sm-6 col-md-4">
 
     {% with group_show=script.script_group|valid_user:request.user %}
@@ -45,3 +46,4 @@
         {% endif %}
     {% endwith %}
 </div>
+{% endif %}


### PR DESCRIPTION
This fixes support for the `WOOEY_SHOW_LOCKED_SCRIPTS = False` setting.

Fixes #82 