### PR TITLE
Platform specific detection of django-admin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ install:
   - "%PYTHON%/python.exe C:/get-pip.py"
   - "%PYTHON%/Scripts/pip.exe install -r requirements.txt"
   - "%PYTHON%/Scripts/pip.exe install -e ."
+# setup our path to include python scripts
+  - cmd: SET PATH=%PATH%;%PYTHON%/Scripts
 build: off
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - PYTHON: "C:/Python34"
 init:
   - "ECHO %PYTHON%"
+  - "ECHO %path%"
   - ps: "ls C:/Python*"
 install:
   - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')

--- a/wooey/backend/command_line.py
+++ b/wooey/backend/command_line.py
@@ -43,6 +43,18 @@ def bootstrap(env=None, cwd=None):
     env['DJANGO_SETTINGS_MODULE'] = ''
     admin_command = [sys.executable] if sys.executable else []
     admin_path = which('django-admin.py')
+    if admin_path is None:
+        # on windows, we may need to look for django-admin.exe
+        platform = sys.platform
+        if platform == "win32":
+            admin_path = which('django-admin')
+            if admin_path is None:
+                admin_path = which('django-admin.exe')
+                if admin_path is not None:
+                    admin_command = []
+    if admin_path is None:
+        sys.stderr.write('Unable to find django-admin command. Please check your PATH and ensure django-admin is accessible.\n')
+        sys.exit(1)
     admin_command.extend([admin_path, 'startproject', project_name])
     admin_kwargs = {'env': env}
     if cwd is not None:

--- a/wooey/tests/factories.py
+++ b/wooey/tests/factories.py
@@ -45,7 +45,7 @@ class BaseJobFactory(factory.DjangoModelFactory):
 
 
 def generate_script(script_path):
-    filename = os.path.join(script_path)[1]
+    filename = os.path.split(script_path)[1]
     filename = os.path.join(wooey_settings.WOOEY_SCRIPT_DIR, filename)
     new_file = default_storage.save(filename, open(script_path))
     from ..backend import utils


### PR DESCRIPTION
This handles cases on Windows where django-admin may not be called django-admin.py (and be an executable that cannot be called with python).

It fixes #104 and #102.