### PR TITLE
Fixed the TypeError __init__() takes exactly 5 arguments (4 given) pr…

### DIFF
--- a/wooey/templates/wooey/registration/login_header.html
+++ b/wooey/templates/wooey/registration/login_header.html
@@ -10,7 +10,7 @@
   </div>
     <input type="hidden" name="next" value="{{ request.path }}" />
   <button type="submit" class="btn btn-default btn-sm" id="wooey-login">{% trans "Login" %}</button>
-{% get_wooey_setting "WOOEY_REGISTER_URL" as registration_url %}
+{% assign_wooey_setting "WOOEY_REGISTER_URL" as registration_url %}
 {% if registration_url %}
 {#    This is a hack but it gets register aligned properly without any work#}
     <div class="form-group"><li>&nbsp;&nbsp;<a href="{% url "wooey:wooey_register" %}">{% trans "Register" %}</a></li></div>

--- a/wooey/templates/wooey/scripts/script_panel.html
+++ b/wooey/templates/wooey/scripts/script_panel.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load wooey_tags %}
-{% get_wooey_setting "WOOEY_SHOW_LOCKED_SCRIPTS" as wooey_show_locked_scripts %}
+{% assign_wooey_setting "WOOEY_SHOW_LOCKED_SCRIPTS" as wooey_show_locked_scripts %}
 {% if script.is_active or wooey_show_locked_scripts %}
 <div class="col-sm-6 col-md-4">
 

--- a/wooey/templatetags/wooey_tags.py
+++ b/wooey/templatetags/wooey_tags.py
@@ -1,12 +1,15 @@
 from __future__ import division, absolute_import
+
 from django import template
-from .. import settings as wooey_settings
 from django.utils.safestring import mark_safe
 from django.contrib.contenttypes.models import ContentType
 from django.template import Library
 
 import urllib
 import hashlib
+
+from .. import settings as wooey_settings
+from ..version import DJ18, DJANGO_VERSION
 
 
 register = Library()

--- a/wooey/templatetags/wooey_tags.py
+++ b/wooey/templatetags/wooey_tags.py
@@ -24,9 +24,15 @@ def get_user_favorite_count(user, app, model):
     return str(favorites_count)
 
 
-@register.assignment_tag
 def assign_wooey_setting(name):
     return getattr(wooey_settings, name, "")
+
+
+# Django 1.9 > Support for assign wooey setting
+if DJANGO_VERSION <= DJ18:
+    register.assignment_tag(assign_wooey_setting)
+else:
+    register.simple_tag(assign_wooey_setting)
 
 
 @register.simple_tag
@@ -130,7 +136,12 @@ def get_range(value):
     return range(int(value))
 
 
-@register.assignment_tag(takes_context=True)
 def absolute_url(context, url):
     request = context['request']
     return request.build_absolute_uri(url)
+
+# Django 1.9 > Support for assign wooey setting
+if DJANGO_VERSION <= DJ18:
+    register.assignment_tag(absolute_url, takes_context=True)
+else:
+    register.simple_tag(absolute_url, takes_context=True)

--- a/wooey/templatetags/wooey_tags.py
+++ b/wooey/templatetags/wooey_tags.py
@@ -81,7 +81,7 @@ def get_user_favorite_count(user, app, model):
     return str(favorites_count)
 
 
-@register.simple_assignment_tag
+@register.simple_tag
 def get_wooey_setting(name):
     return getattr(wooey_settings, name, "")
 


### PR DESCRIPTION
…oblem

In Django 1.9 you get following error: 
    TypeError at /wooey/
    __init__() takes exactly 5 arguments (4 given)

This is because you use the wrong decorator. This commit will fix it