### PR TITLE
Pass task_completed task if it is not a wooey_job

### DIFF
--- a/wooey/signals.py
+++ b/wooey/signals.py
@@ -12,6 +12,10 @@ from celery.signals import task_postrun, task_prerun, task_revoked
 def task_completed(sender=None, **kwargs):
     task_kwargs = kwargs.get('kwargs')
     job_id = task_kwargs.get('wooey_job')
+    # Just return if it is not a wooey_job!
+    if not job_id:
+        return
+
     from .models import WooeyJob
     from celery import states
     try:


### PR DESCRIPTION
If you call a celery task with .delay() he will send a postrun for this function

It has to prove if the postrun is a wooey_job