### PR TITLE
Fix arguments being overriden

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,10 @@ nose
 factory-boy
 coveralls
 six
-clinto==0.1.2
+clinto
 tox
 boto
 django-storages-redux
 sphinx
 mock
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ nose
 factory-boy
 coveralls
 six
-clinto
+clinto==0.1.3
 tox
 boto
 django-storages-redux

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     scripts=['scripts/wooify'],
     entry_points={'console_scripts': ['wooify = wooey.backend.command_line:bootstrap', ]},
-    install_requires = ['Django>=1.6', 'django-autoslug', 'django-celery', 'six', 'clinto==0.1.2'],
+    install_requires = ['Django>=1.6', 'django-autoslug', 'django-celery', 'six', 'clinto>=0.1.3'],
     include_package_data=True,
     description='A Django app which creates a web GUI and task interface for argparse scripts',
     url='http://www.github.com/wooey/wooey',

--- a/wooey/models/core.py
+++ b/wooey/models/core.py
@@ -295,10 +295,12 @@ class ScriptParameter(UpdateScriptsMixin, WooeyPy2Mixin, models.Model):
     slug = AutoSlugField(populate_from='script_param', unique=True)
     is_output = models.BooleanField(default=None)
     required = models.BooleanField(default=False)
-    # output_path = models.FilePathField(path=settings.MEDIA_ROOT, allow_folders=True, allow_files=False,
-    #                                    recursive=True, max_length=255)
     choices = models.CharField(max_length=255, null=True, blank=True)
     choice_limit = models.CharField(max_length=10, null=True, blank=True)
+    collapse_arguments = models.BooleanField(
+        default=True,
+        help_text=_('Collapse separate inputs to a given argument to a single input (ie: --arg 1 --arg 2 becomes --arg 1 2)')
+    )
     form_field = models.CharField(max_length=255)
     default = models.CharField(max_length=255, null=True, blank=True)
     input_type = models.CharField(max_length=255)
@@ -388,7 +390,7 @@ class ScriptParameters(WooeyPy2Mixin, models.Model):
             return None
         field = self.parameter.form_field
         param = self.parameter.short_param
-        com = {'parameter': param}
+        com = {'parameter': param, 'script_parameter': self.parameter}
         if field == self.BOOLEAN:
             if value:
                 return com

--- a/wooey/tests/scripts/choices.py
+++ b/wooey/tests/scripts/choices.py
@@ -6,11 +6,11 @@ parser.add_argument('--one-choice', choices=[0, 1, 2, 3], nargs=1)
 parser.add_argument('--two-choices', choices=[0, 1, 2, 3], nargs=2)
 parser.add_argument('--at-least-one-choice', choices=[0, 1, 2, 3], nargs='+')
 parser.add_argument('--all-choices', choices=[0, 1, 2, 3], nargs='*')
-parser.add_argument('--need-at-least-one-numbers', type=int, nargs='+', required=True)
+parser.add_argument('--need-at-least-one-numbers', type=int, nargs='+', required=True, action='append')
 parser.add_argument('--choices-str', nargs='+', type=str)
 parser.add_argument('--multiple-file-choices', type=argparse.FileType('r'), nargs='*')
 parser.add_argument('--more-multiple-file-choices', type=argparse.FileType('r'), nargs='*')
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    sys.stdout.write('{}'.format(args.multiple_file_choices))
+    sys.stdout.write('{}'.format(args))

--- a/wooey/tests/test_scripts.py
+++ b/wooey/tests/test_scripts.py
@@ -17,7 +17,7 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, mixins.FileMixin, TestCase)
             new_file = self.storage.save(self.filename_func('command_order.py'), o)
         res = utils.add_wooey_script(script_path=new_file, group=None)
         self.assertEqual(res['valid'], True, res['errors'])
-        job = utils.create_wooey_job(script_version_pk=1, data={'job_name': 'abc', 'link': 'alink', 'name': 'aname'})
+        job = utils.create_wooey_job(script_version_pk=res['script'].pk, data={'job_name': 'abc', 'link': 'alink', 'name': 'aname'})
         # These are positional arguments -- we DO NOT want them returning anything
         self.assertEqual(['', ''], [i.parameter.short_param for i in job.get_parameters()])
         # These are the params shown to the user, we want them returning their destination
@@ -26,6 +26,15 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, mixins.FileMixin, TestCase)
         # Check the job command
         commands = utils.get_job_commands(job=job)[2:]
         self.assertEqual(['alink', 'aname'], commands)
+
+    def test_collapse_arguments(self):
+        job = utils.create_wooey_job(script_version_pk=self.choice_script.pk, data={'job_name': 'abc', 'need_at_least_one_numbers': [1,2]})
+        commands = utils.get_job_commands(job=job)[2:]
+        self.assertEqual(commands, ['--need-at-least-one-numbers', '1', '2'])
+        job = utils.create_wooey_job(script_version_pk=self.choice_script.pk,
+                                     data={'job_name': 'abc', 'choices_str': [1, 2, 3]})
+        commands = utils.get_job_commands(job=job)[2:]
+        self.assertEqual(commands, ['--choices-str', '1', '--choices-str', '2', '--choices-str', '3'])
 
     def test_script_upgrade(self):
         script_path = os.path.join(config.WOOEY_TEST_SCRIPTS, 'command_order.py')


### PR DESCRIPTION
This fixes #94. Let me know if you see anything I may not have thought of @mfitzp. The case can be examined by the activity of the 'choices.py' script. This also required an update to clinto.