### PR TITLE
Scripts without any arguments fail to run

### DIFF
--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -145,16 +145,19 @@ class WooeyFormFactory(object):
             })
             group['fields'][param.slug] = field
             group_map[group_id] = group
+
+        form = WooeyForm()
+        form.fields['wooey_type'] = script_id_field
+        form.fields['wooey_type'].initial = pk
+        d = {'action': script_version.get_url(), 'wooey_form': form}
+
         # create individual forms for each group
-        group_map = OrderedDict([(i, group_map[i]) for i in sorted(group_map.keys())])
-        d = {'action': script_version.get_url(), 'groups': []}
+        d['groups'] = []
         pk = script_version.pk
+        group_map = OrderedDict([(i, group_map[i]) for i in sorted(group_map.keys())])
         for group_index, group in enumerate(six.iteritems(group_map)):
             group_pk, group_info = group
             form = WooeyForm()
-            if group_index == 0:
-                form.fields['wooey_type'] = script_id_field
-                form.fields['wooey_type'].initial = pk
             for field_pk, field in six.iteritems(group_info['fields']):
                 form.fields[field_pk] = field
 

--- a/wooey/forms/factory.py
+++ b/wooey/forms/factory.py
@@ -146,14 +146,14 @@ class WooeyFormFactory(object):
             group['fields'][param.slug] = field
             group_map[group_id] = group
 
-        form = WooeyForm()
+        pk = script_version.pk
+        form = WooeyForm(initial={'wooey_type': pk})
         form.fields['wooey_type'] = script_id_field
         form.fields['wooey_type'].initial = pk
         d = {'action': script_version.get_url(), 'wooey_form': form}
 
         # create individual forms for each group
         d['groups'] = []
-        pk = script_version.pk
         group_map = OrderedDict([(i, group_map[i]) for i in sorted(group_map.keys())])
         for group_index, group in enumerate(six.iteritems(group_map)):
             group_pk, group_info = group

--- a/wooey/templates/wooey/scripts/script_view.html
+++ b/wooey/templates/wooey/scripts/script_view.html
@@ -30,6 +30,7 @@
 
     <form id="wooey-job-form" method="POST" action="{{ form.action }}" enctype="multipart/form-data">
         {% csrf_token %}
+        {{ form.wooey_form }}
 
         <div class="panel panel-default">
         <div class="panel-heading">

--- a/wooey/tests/test_forms.py
+++ b/wooey/tests/test_forms.py
@@ -101,3 +101,10 @@ class FormTestCase(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase)
         # get the job again
         job = WooeyJob.objects.get(pk=job.pk)
         self.assertEqual(job.status, WooeyJob.COMPLETED)
+
+    def test_wooey_form(self):
+        # Make sure wooey form exists and has everything we need in it
+        script_version = self.without_args
+        forms = utils.get_form_groups(script_version=self.without_args)
+        wooey_form = forms['wooey_form']
+        self.assertDictEqual(wooey_form.initial, {'wooey_type': script_version.pk})

--- a/wooey/tests/test_views.py
+++ b/wooey/tests/test_views.py
@@ -182,7 +182,6 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         script_version = self.without_args
         forms = utils.get_form_groups(script_version=self.without_args)
         data = {}
-        import pdb; pdb.set_trace();
         for form in chain(forms['groups'], [forms['wooey_form']]):
             initial = form.initial
             initial.update(config.SCRIPT_DATA['without_args'].get('data'))

--- a/wooey/tests/test_views.py
+++ b/wooey/tests/test_views.py
@@ -1,6 +1,7 @@
 # TODO: Test for viewing a user's job as an anonymous user (fail case)
 
 import json
+from itertools import chain
 
 from django.test import TestCase, RequestFactory, Client
 from django.core.urlresolvers import reverse
@@ -10,6 +11,7 @@ from django.http import Http404
 from nose.tools import raises
 
 from . import factories, mixins, config
+from ..backend import utils
 from ..views import wooey_celery
 from .. import views as wooey_views
 from .. import settings
@@ -173,3 +175,23 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         job = WooeyJob.objects.latest('created_date')
         new_files = [i.value.url for i in job.get_parameters() if i.parameter.slug == 'multiple_file_choices']
         self.assertEqual(len(new_files), len(files))
+
+
+    def test_form_groups(self):
+        # Make sure forms groups work to validate
+        script_version = self.without_args
+        forms = utils.get_form_groups(script_version=self.without_args)
+        data = {}
+        import pdb; pdb.set_trace();
+        for form in chain(forms['groups'], [forms['wooey_form']]):
+            initial = form.initial
+            initial.update(config.SCRIPT_DATA['without_args'].get('data'))
+            data.update(initial)
+
+        url = reverse('wooey:wooey_script', kwargs={'slug': script_version.script.slug})
+        request = self.factory.post(url, data=data)
+        user = factories.UserFactory()
+        request.user = user
+        response = self.script_view_func(request)
+        d = load_JSON_dict(response.content)
+        self.assertTrue(d['valid'], d)


### PR DESCRIPTION
Because the wooey form info is rendered with an argument group, scripts without any arguments will fail to populate this information. This PR moves the wooey form info to its own form element to handle these types of scripts