### PR TITLE
Stop bootstrap migration creation

### DIFF
--- a/wooey/backend/command_line.py
+++ b/wooey/backend/command_line.py
@@ -110,7 +110,6 @@ def bootstrap(env=None, cwd=None):
     shutil.move(os.path.join(project_base_dir, 'urls.py'), os.path.join(project_base_dir, 'urls', 'django_urls.py'))
     env['DJANGO_SETTINGS_MODULE'] = '.'.join([project_name, 'settings', 'user_settings'])
     if django_compat.DJANGO_VERSION >= django_compat.DJ17:
-        subprocess.call(['python', 'manage.py', 'makemigrations'], env=env, cwd=project_root)
         subprocess.call(['python', 'manage.py', 'migrate'], env=env, cwd=project_root)
     else:
         subprocess.call(['python', 'manage.py', 'syncdb', '--noinput'], env=env, cwd=project_root)


### PR DESCRIPTION
Do not makemigrations on project bootstrap to prevent things like upload_dir from being created in a migration