### PR TITLE
Upgrade celery to 4.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto
-celery==4.1.0
+celery==4.2.1
 clinto>=0.2.0
 coveralls
 django<2


### PR DESCRIPTION
Fixes requirements.txt to not use the broken 4.1.0 release