### PR TITLE
Fix multiple argument parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,35 @@ test:
 	coverage run --append --branch --source=wooey `which django-admin.py` test --settings=wooey.test_settings wooey.tests
 	coverage report --omit='*migrations*','*wooey_scripts*','*tests/scripts*','*conf/*'
 
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+
+dist: clean ## builds source and wheel package
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+release: dist ## package and upload a release
+	twine upload dist/*
+
 .PHONY: docs
 docs:
 	cd docs && make html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto
 celery==4.2.1
-clinto>=0.2.0
+clinto>=0.3.0
 coveralls
 django<2
 django-autoslug

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     entry_points={'console_scripts': ['wooify = wooey.backend.command_line:bootstrap', ]},
     install_requires=[
         'celery>=4.0,<5',
-        'clinto>=0.2.0',
+        'clinto>=0.3.0',
         'Django>=1.8,<2',
         'django-autoslug',
         'django-celery-results',

--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -15,6 +15,7 @@ from operator import itemgetter
 from pkg_resources import parse_version
 
 from clinto.parser import Parser
+from clinto.parsers.constants import SPECIFY_EVERY_PARAM
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import transaction
@@ -441,7 +442,7 @@ def add_wooey_script(script_version=None, script_path=None, group=None, script_n
                     'param_help': param.get('help'),
                     'is_checked': param.get('checked', False),
                     # parameter_group': param_group,
-                    'collapse_arguments': 'collapse_arguments' in param.get('param_action', set()),
+                    'collapse_arguments': SPECIFY_EVERY_PARAM not in param.get('param_action', set()),
                 }
 
                 parameter_index += 1

--- a/wooey/tests/test_scripts.py
+++ b/wooey/tests/test_scripts.py
@@ -53,7 +53,7 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, mixins.FileMixin, TestCase)
             }
         )
         commands = utils.get_job_commands(job=job)[2:]
-        self.assertEqual(commands, ['--need-at-least-one-numbers', '1', '2'])
+        self.assertEqual(commands, ['--need-at-least-one-numbers', '1', '--need-at-least-one-numbers', '2'])
 
         slug = test_utils.get_subparser_form_slug(self.choice_script, 'choices_str')
         job = utils.create_wooey_job(
@@ -64,7 +64,7 @@ class ScriptAdditionTests(mixins.ScriptFactoryMixin, mixins.FileMixin, TestCase)
             }
         )
         commands = utils.get_job_commands(job=job)[2:]
-        self.assertEqual(commands, ['--choices-str', '1', '--choices-str', '2', '--choices-str', '3'])
+        self.assertEqual(commands, ['--choices-str', '1', '2', '3'])
 
     def test_script_upgrade(self):
         script_path = os.path.join(config.WOOEY_TEST_SCRIPTS, 'translate.py')

--- a/wooey/tests/test_utils.py
+++ b/wooey/tests/test_utils.py
@@ -20,11 +20,6 @@ class TestUtils(mixins.ScriptFactoryMixin, mixins.FileMixin, TestCase):
     def test_sanitize_string(self):
         assert(utils.sanitize_string('ab"c')) == 'ab\\"c'
 
-    def test_add_script(self):
-        pass
-        # TODO: fix me
-        # utils.add_wooey_script(script=os.path.join(config.WOOEY_TEST_SCRIPTS, 'translate.py'))
-
     def test_anonymous_users(self):
         from .. import settings as wooey_settings
         from django.contrib.auth.models import AnonymousUser


### PR DESCRIPTION
The logic for collapse_args is inverted, where the parameter key should be specified for each value only if an `action='append'` like option in enabled. This addresses https://github.com/wooey/Wooey/issues/269