### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -103,7 +103,7 @@ middleware, and before the CommonMiddleware e.g.
         'django.middleware.security.SecurityMiddleware',
     )
 
-For more information on the internationlization middelware see
+For more information on the internationlization middleware see
 `the Django documentation <https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#how-django-discovers-language-preference>`_.
 
 Note that if a user's browser does not request an available language the language

--- a/docs/heroku.rst
+++ b/docs/heroku.rst
@@ -19,7 +19,7 @@ or if you want to be on the bleeding-edge for some reason, from the github repo 
 Bootstrapping Wooey
 -------------------
 
-The wooey project can be boostraped, which will create a full-fledged django app for you. This can be accomplished with the command:
+The wooey project can be bootstrap, which will create a full-fledged django app for you. This can be accomplished with the command:
 
 ::
 

--- a/docs/wooey_ui.rst
+++ b/docs/wooey_ui.rst
@@ -18,7 +18,7 @@ Running scripts
 ---------------
 
 Scripts may be accessed via the homepage or by searching for scripts in the
-script search. Searching for scripts is accssible via the left menu sidebar
+script search. Searching for scripts is accessible via the left menu sidebar
 that is viewable by clicking the menu button on the left side of the header.
 From the script panel, scripts can be parameterized and executed by Wooey.
 If a script has subparsers, they are accessible via a dropdown menu on

--- a/wooey/views/favorite.py
+++ b/wooey/views/favorite.py
@@ -15,7 +15,7 @@ from ..models import Favorite
 @ensure_csrf_cookie
 def toggle_favorite(request):
     """
-    Add/remove an object to the user's favorites. Checks for existance and adds if not, else removes.
+    Add/remove an object to the user's favorites. Checks for existence and adds if not, else removes.
     This is the underlying mechanism for adding items to the user 'scrapbook' and favorite scripts.
 
     :param request:


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- docs/heroku.rst
- docs/wooey_ui.rst
- wooey/views/favorite.py

Fixes:
- Should read `middleware` rather than `middelware`.
- Should read `existence` rather than `existance`.
- Should read `bootstrap` rather than `boostraped`.
- Should read `accessible` rather than `accssible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md