### PR TITLE
fix HTML search in Django >= 1.8

### DIFF
--- a/wooey/tests/test_views.py
+++ b/wooey/tests/test_views.py
@@ -313,3 +313,65 @@ class WooeyViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
         response = self.json_view_func(request)
         d = load_JSON_dict(response.content)
         self.assertFalse(d['valid'], d)
+
+class WoeeyScriptSearchViews(mixins.ScriptFactoryMixin, mixins.FileCleanupMixin, TestCase):
+    def setUp(self):
+        super(WoeeyScriptSearchViews, self).setUp()
+        self.factory = RequestFactory()
+        self.json_view_func = wooey_views.WooeyScriptSearchJSON.as_view()
+        self.json_html_view_func = wooey_views.WooeyScriptSearchJSONHTML.as_view()
+        # the test server doesn't have celery running
+        settings.WOOEY_CELERY = False
+
+        self.script1 = factories.ScriptFactory(
+            script_name='test script 1 name',
+            script_description='test script 1 description',
+        )
+        self.script2 = factories.ScriptFactory(
+            script_name='test script 2 name',
+            script_description='test script 2 description',
+        )
+
+    def test_search_json_with_name(self):
+        url = reverse('wooey:wooey_search_script_json')
+        request = self.factory.get(url, data={'q': '1 name'})
+        response = self.json_view_func(request)
+        d = load_JSON_dict(response.content)
+        self.assertEqual(len(d['results']), 1)
+        self.assertEqual(
+            set(result['id'] for result in d['results']),
+            {self.script1.id}
+        )
+
+    def test_search_json_with_description(self):
+        url = reverse('wooey:wooey_search_script_json')
+        request = self.factory.get(url, data={'q': '2 description'})
+        response = self.json_view_func(request)
+        d = load_JSON_dict(response.content)
+        self.assertEqual(len(d['results']), 1)
+        self.assertEqual(
+            set(result['id'] for result in d['results']),
+            {self.script2.id}
+        )
+
+    def test_search_json_html_with_name(self):
+        url = reverse('wooey:wooey_search_script_jsonhtml')
+        request = self.factory.get(url, data={'q': '1 name'})
+        response = self.json_view_func(request)
+        d = load_JSON_dict(response.content)
+        self.assertEqual(len(d['results']), 1)
+        self.assertEqual(
+            set(result['id'] for result in d['results']),
+            {self.script1.id}
+        )
+
+    def test_search_json_html_with_description(self):
+        url = reverse('wooey:wooey_search_script_jsonhtml')
+        request = self.factory.get(url, data={'q': '2 description'})
+        response = self.json_view_func(request)
+        d = load_JSON_dict(response.content)
+        self.assertEqual(len(d['results']), 1)
+        self.assertEqual(
+            set(result['id'] for result in d['results']),
+            {self.script2.id}
+        )

--- a/wooey/views/views.py
+++ b/wooey/views/views.py
@@ -14,6 +14,7 @@ from django.views.generic import DetailView, TemplateView, View
 
 from ..backend import utils
 from ..models import WooeyJob, Script, UserFile, Favorite, ScriptVersion
+from ..version import DJANGO_VERSION, DJ18
 from .. import settings as wooey_settings
 
 
@@ -265,5 +266,14 @@ class WooeyScriptSearchJSONHTML(WooeyScriptSearchBase):
     def search(self, request):
         results = []
         for script in self.search_results:
-            results.append(render_to_string('wooey/scripts/script_panel.html', {'script': script}, context_instance=RequestContext(request)))
+            # context_instance kwarg was deprecated in Django 1.8
+            render = render_to_string(
+                'wooey/scripts/script_panel.html',
+                {'script': script, 'request': request}
+            ) if DJANGO_VERSION >= DJ18 else render_to_string(
+                'wooey/scripts/script_panel.html',
+                {'script': script},
+                context_instance=RequestContext(request)
+            )
+            results.append(render)
         return JsonResponse({'results': results})


### PR DESCRIPTION
The `context_instance` kwarg to `render_to_string` has been deprecated since Django 1.8. Added a check for the Django version to call the function with correct arguments.