### PR TITLE
Disable pre_save and post_save signals during loaddata

### DIFF
--- a/wooey/signals.py
+++ b/wooey/signals.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from functools import wraps
 
 from django.db.models.signals import pre_save, post_save
 from django.db.utils import InterfaceError, DatabaseError
@@ -7,6 +8,23 @@ from django import db
 from celery.signals import task_postrun, task_prerun
 
 from .models import ScriptVersion
+
+
+def disable_for_loaddata(signal_handler):
+    """Function decorator to disable pre_save/post_save functions when
+    fixtures are being loaded. The `raw` keyword argument indicates whether
+    the model should be save as-is (i.e. when loading a fixture).
+
+    https://docs.djangoproject.com/en/4.0/ref/signals/
+    https://stackoverflow.com/a/11409794
+    """
+    @wraps(signal_handler)
+    def wrapper(*args, **kwargs):
+        if kwargs['raw']:
+            print('Skipping signal for {} {}'.format(args, kwargs))
+            return
+        signal_handler(*args, **kwargs)
+    return wrapper
 
 
 @task_postrun.connect
@@ -35,7 +53,7 @@ def task_completed(sender=None, **kwargs):
 def skip_script(instance):
     return getattr(instance, '_script_cl_creation', False) or getattr(instance, '_script_upgrade', False) or getattr(instance, '_rename_script', False)
 
-
+@disable_for_loaddata
 def script_version_presave(instance, **kwargs):
     created = instance.pk is None
     from .backend import utils
@@ -50,7 +68,7 @@ def script_version_presave(instance, **kwargs):
                 instance._script_upgrade = True
                 instance.pk = None
 
-
+@disable_for_loaddata
 def script_version_postsave(instance, created, **kwargs):
     from .backend import utils
     if created and (not skip_script(instance) or getattr(instance, '_script_upgrade', False)):

--- a/wooey/signals.py
+++ b/wooey/signals.py
@@ -20,10 +20,8 @@ def disable_for_loaddata(signal_handler):
     """
     @wraps(signal_handler)
     def wrapper(*args, **kwargs):
-        if kwargs['raw']:
-            print('Skipping signal for {} {}'.format(args, kwargs))
-            return
-        signal_handler(*args, **kwargs)
+        if not kwargs['raw']:
+            signal_handler(*args, **kwargs)
     return wrapper
 
 


### PR DESCRIPTION
This PR adds functionality to disable `pre_save` and `post_save` signals when the `raw` keyword argument is `True`, which is the case when fixtures are being loaded via the `loaddata` Django admin command.

This makes it overall easier to set up fixtures and seed the database for local development. If the signals are not disabled, every time a fixture for a `ScriptVersion` is being loaded, the backend tries to validate the script (which doesn't actually exist as a file on the host).