### PR TITLE
Fix Defalt typo -> Default

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,15 +46,15 @@ storing real time updates from running jobs.
 system, the registration url: (Default: ``'/accounts/register/'``)
 
 :code:`WOOEY_SCRIPT_DIR`: String, the folder to save scripts under. It should
-be a short, relative path to the storage root. (Defalt: ``wooey_scripts``)
+be a short, relative path to the storage root. (Default: ``wooey_scripts``)
 
 :code:`WOOEY_SHOW_LOCKED_SCRIPTS`: Boolean, whether to show locked
-scripts as disabled or hide them entirely. (Defalt: ``True`` -- show as
+scripts as disabled or hide them entirely. (Default: ``True`` -- show as
 disabled)
 
-:code:`WOOEY_SITE_NAME`: String, the name of the site to display. (Defalt: ``Wooey!``)
+:code:`WOOEY_SITE_NAME`: String, the name of the site to display. (Default: ``Wooey!``)
 
-:code:`WOOEY_SITE_TAG`: String, the tagline for the site. (Defalt: ``A web UI for Python Scripts``)
+:code:`WOOEY_SITE_TAG`: String, the tagline for the site. (Default: ``A web UI for Python Scripts``)
 
 
 Internationlization (i18n)


### PR DESCRIPTION
Fixes typo in the docs "Defalt" should be "Default"