### PR TITLE
add save_formset to ScriptAdmin

### DIFF
--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -34,16 +34,14 @@ class ScriptAdmin(ModelAdmin):
         js = (os.path.join("wooey", "js", "admin", "script.js"),)
 
     def save_formset(self, request, form, formset, change):
-        if formset.model == ScriptVersion:
-            instances = formset.save(commit=False)
-            for instance in instances:
-                if not change:
-                    instance.created_by = request.user
-                instance.modified_by = request.user
-                instance.save()
-        else:
-            formset.save()
-
+        instances = formset.save(commit=False)
+        for obj in instances:
+            if isinstance(obj, ScriptVersion):
+                if obj.id:
+                    obj.created_by = request.user
+                else:
+                    obj.updated_by = request.user
+        formset.save()
 
 class ParameterAdmin(ModelAdmin):
     list_display = ("script_versions", "parameter_group", "short_param")

--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -42,6 +42,7 @@ class ScriptAdmin(ModelAdmin):
                 obj.modified_by = request.user
         formset.save()
 
+
 class ParameterAdmin(ModelAdmin):
     list_display = ("script_versions", "parameter_group", "short_param")
 

--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -39,7 +39,7 @@ class ScriptAdmin(ModelAdmin):
             if isinstance(obj, ScriptVersion):
                 if not obj.id:
                     obj.created_by = request.user
-                obj.updated_by = request.user
+                obj.modified_by = request.user
         formset.save()
 
 class ParameterAdmin(ModelAdmin):

--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -37,10 +37,9 @@ class ScriptAdmin(ModelAdmin):
         instances = formset.save(commit=False)
         for obj in instances:
             if isinstance(obj, ScriptVersion):
-                if obj.id:
+                if not obj.id:
                     obj.created_by = request.user
-                else:
-                    obj.updated_by = request.user
+                obj.updated_by = request.user
         formset.save()
 
 class ParameterAdmin(ModelAdmin):

--- a/wooey/admin.py
+++ b/wooey/admin.py
@@ -33,6 +33,17 @@ class ScriptAdmin(ModelAdmin):
     class Media:
         js = (os.path.join("wooey", "js", "admin", "script.js"),)
 
+    def save_formset(self, request, form, formset, change):
+        if formset.model == ScriptVersion:
+            instances = formset.save(commit=False)
+            for instance in instances:
+                if not change:
+                    instance.created_by = request.user
+                instance.modified_by = request.user
+                instance.save()
+        else:
+            formset.save()
+
 
 class ParameterAdmin(ModelAdmin):
     list_display = ("script_versions", "parameter_group", "short_param")


### PR DESCRIPTION
Add `save_formset` method to `ScriptAdmin` so that when script versions are added from the inline table, the `created_by` and `modified_by` fields get set appropriately.