### PR TITLE
Improve home view script sorting

### DIFF
--- a/wooey/views/views.py
+++ b/wooey/views/views.py
@@ -178,9 +178,16 @@ class WooeyHomeView(TemplateView):
         if self.request.user.is_authenticated:
             # Get the id of every favorite (scrapbook) file
             ctype = ContentType.objects.get_for_model(Script)
-            ctx["favorite_script_ids"] = Favorite.objects.filter(
+            favorite_scripts = Favorite.objects.filter(
                 content_type=ctype, user__id=self.request.user.id
             ).values_list("object_id", flat=True)
+            ctx["favorite_script_ids"] = favorite_scripts
+            # put favorite scripts at the top of the sort order
+            ctx["scripts"] = sorted(
+                ctx["scripts"],
+                key=lambda x: (x.id in favorite_scripts, x.script_name),
+                reverse=True,
+            )
         else:
             ctx["favorite_script_ids"] = []
 

--- a/wooey/views/views.py
+++ b/wooey/views/views.py
@@ -185,8 +185,9 @@ class WooeyHomeView(TemplateView):
             # put favorite scripts at the top of the sort order
             ctx["scripts"] = sorted(
                 ctx["scripts"],
-                key=lambda x: (x.id in favorite_scripts, x.script_name),
-                reverse=True,
+                # we do the `not` so we can sort in ascending order for both the
+                # favorite status and get alphabetical sorting
+                key=lambda x: (x.id not in favorite_scripts, x.script_name),
             )
         else:
             ctx["favorite_script_ids"] = []


### PR DESCRIPTION
This has 2 impacts:
* Scripts marked as "favorite" will show up first
* Scripts will be sorted alphabetically

As an instance gets more scripts, it becomes quite cumbersome to find where a script is.