### PR TITLE
Parse URL query parameters to prepopulate subparser and script parameters

### DIFF
--- a/docs/wooey_ui.rst
+++ b/docs/wooey_ui.rst
@@ -43,3 +43,27 @@ to parse this information), updates to the script version will result in a new
 version being created. If a command line library doesn't support versioning
 or the version has not been updated in a script, the Script Iteration counter
 will be incremented.
+
+Using URL parameters to pre-populate script parameters
+------------------------------------------------------
+
+Wooey supports pre-populating script parameters via URL parameters. This is
+useful for providing a link to a script with some parameters already set. The
+following rules apply.
+
+* URL parameters are specified as :code:`?parameter=value`
+* Multiple parameters may be specified by separating them with :code:`&`.
+  For example, :code:`?parameter1=value1&parameter2=value2`.
+* Parameters are specified by the name used in the script, **but in snake case**.
+  For example, a parameter named :code:`--my-parameter` would be specified as
+  :code:`?my_parameter=value`.
+* If a parameter is a flag, passing any value will set the flag. For example,
+  :code:`?my_flag=1` or :code:`?my_flag=true` will set the flag.
+* If a parameter accepts multiple values (:code:`nargs`), the values are specified
+  by passing the parameter multiple times. For example, :code:`?my_parameter=1&my_parameter=2`
+  will set the parameter to have two values filled out: :code:`1` and :code:`2`.
+  If a parameter does not support multiple values and multiple values are passed,
+  the last value will be used.
+* If the script has subparsers, the :code:`__subparser` parameter is used to specify
+  the subparser to use. For example, :code:`?__subparser=mysubparser` will select the
+  subparser named :code:`mysubparser`.

--- a/wooey/templates/wooey/scripts/script_view.html
+++ b/wooey/templates/wooey/scripts/script_view.html
@@ -56,7 +56,7 @@
               <ul class="dropdown-menu">
                 {% for parser_info, parser_groups in form.parsers.items %}
                   {% with parser_pk=parser_info.0 parser_name=parser_info.1 %}
-                    <li class="{% if forloop.first %}active{% endif %}"><a data-toggle="tab" data-parser-pk="{{ parser_pk }}" href="#parsergroup-{{ parser_pk }}">{% if not parser_name %}{% trans "Main Parser Parameters" %}{% else %}{{ parser_name|title }}{% endif %}</a></li>
+                    <li class="{% if forloop.first %}active{% endif %}"><a data-toggle="tab" data-parser-pk="{{ parser_pk }}" data-parser-name="{{ parser_name }}" href="#parsergroup-{{ parser_pk }}">{% if not parser_name %}{% trans "Main Parser Parameters" %}{% else %}{{ parser_name|title }}{% endif %}</a></li>
                     {% if forloop.first %}
                       <li role="separator" class="divider"></li>
                     {% endif %}
@@ -263,7 +263,10 @@
           selectWooeyParser($('div[id^=parsergroup-]'))
         }
 
-        var $initial_parser = $("a[data-parser-pk=" + $wooey_parser.val() + "]");
+        // Set initial subparser if present in url params.
+        const urlParams = new URLSearchParams(window.location.search);
+        const subparser = urlParams.get('__subparser');
+        var $initial_parser = $("a[data-parser-name=" + subparser + "]");
         if ($initial_parser.length) {
           $initial_parser.click();
         }

--- a/wooey/tests/mixins.py
+++ b/wooey/tests/mixins.py
@@ -59,6 +59,12 @@ class ScriptTearDown(object):
 
 class ScriptFactoryMixin(ScriptTearDown, object):
     def setUp(self):
+        self.command_order_script_path = os.path.join(
+            config.WOOEY_TEST_SCRIPTS, "command_order.py"
+        )
+        self.command_order_script = factories.generate_script(
+            self.command_order_script_path
+        )
         self.translate_script_path = os.path.join(
             config.WOOEY_TEST_SCRIPTS, "translate.py"
         )

--- a/wooey/views/views.py
+++ b/wooey/views/views.py
@@ -73,6 +73,17 @@ class WooeyScriptBase(DetailView):
                 "script_version", "script_iteration"
             ).last()
 
+        # Set parameter initial values by parsing the URL parameters
+        # and matching them to the script parameters.
+        for param in script_version.get_parameters():
+            if param.script_param in self.request.GET:
+                value = (
+                    self.request.GET.getlist(param.script_param)
+                    if param.multiple_choice
+                    else self.request.GET.get(param.script_param)
+                )
+                initial[param.form_slug] = value
+
         context["form"] = utils.get_form_groups(
             script_version=script_version,
             initial_dict=initial,


### PR DESCRIPTION
Support prepopulating script parameters by parsing URL query parameters. This is useful in generating Wooey URLs for user-facing scripts to minimize user error in filling out info that the component generating the URL may already know about.