### PR TITLE
fix: add is_staff authorization check to add_or_update_script API

### DIFF
--- a/wooey/api/scripts.py
+++ b/wooey/api/scripts.py
@@ -4,7 +4,7 @@ import os
 import shlex
 from itertools import groupby
 
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -185,7 +185,19 @@ def submit_script(request, slug=None):
 @requires_login
 def add_or_update_script(request):
     if not request.user.is_staff:
-        return HttpResponse('Must be staff to upload scripts.', status=403)
+        return JsonResponse(
+            {
+                "valid": False,
+                "errors": {
+                    "__all__": [
+                        force_str(
+                            _("You do not have permission to upload scripts.")
+                        )
+                    ]
+                },
+            },
+            status=403,
+        )
     submitted_data = request.POST.dict()
     files = request.FILES
 

--- a/wooey/api/scripts.py
+++ b/wooey/api/scripts.py
@@ -4,7 +4,7 @@ import os
 import shlex
 from itertools import groupby
 
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -184,6 +184,8 @@ def submit_script(request, slug=None):
 @require_http_methods(["POST"])
 @requires_login
 def add_or_update_script(request):
+    if not request.user.is_staff:
+        return HttpResponse('Must be staff to upload scripts.', status=403)
     submitted_data = request.POST.dict()
     files = request.FILES
 


### PR DESCRIPTION
### Summary

The `add_or_update_script` API endpoint (`/api/scripts/v1/add-or-update/`) currently only verifies that a user is authenticated via the `@requires_login` decorator, but does not check whether the user has staff/admin privileges. This allows any registered (non-admin) user to upload and register arbitrary Python scripts, which are subsequently executed by Celery workers — resulting in **Remote Code Execution (RCE)**.

This PR adds an `is_staff` authorization check at the entry point of the `add_or_update_script` function. Non-staff users now receive a `403 Forbidden` response.

### Changes

- **`wooey/api/scripts.py`**: Added `HttpResponse` import and `is_staff` check before script upload processing

```diff
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
```

```diff
 @requires_login
 def add_or_update_script(request):
+    if not request.user.is_staff:
+        return HttpResponse('Must be staff to upload scripts.', status=403)
     submitted_data = request.POST.dict()
```

### Rationale

Per the [official security documentation](https://wooey.readthedocs.io/en/latest/security.html):

> *"scripts must be uploaded by users with administrator privileges"*

The existing code did not enforce this requirement. The `is_staff` field is already used elsewhere in Wooey (e.g., in `profile.html` templates) to identify administrative users, making this fix consistent with the project's existing authorization model.

### Impact

- **Before**: Any authenticated user (including self-registered accounts) could upload arbitrary scripts via API
- **After**: Only users with `is_staff=True` can upload scripts; all others receive `403 Forbidden`
- **No breaking changes**: Normal script execution, job management, and all other functionality remain unaffected
