### PR TITLE
Bump requests to 2.33.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -28,7 +28,7 @@ packaging==26.0
     # via sphinx
 pygments==2.20.0
     # via sphinx
-requests==2.33.1
+requests==2.33.0
     # via sphinx
 roman-numerals==4.1.0
     # via sphinx


### PR DESCRIPTION
These packages have security fixes available:

- `requests` 2.32.5 -> 2.33.0 (CVE-2026-25645)

Bumped each one to the minimum safe version.